### PR TITLE
[AMM] fix(swap.rs): harden swap math and enforce post-swap k invariant

### DIFF
--- a/amm/src/swap.rs
+++ b/amm/src/swap.rs
@@ -15,6 +15,8 @@ pub fn swap(
     min_amount_out: u128,
     token_in_id: AccountId,
 ) -> (Vec<AccountPostState>, Vec<ChainedCall>) {
+    assert!(swap_amount_in > 0, "Swap amount in should be nonzero");
+
     // Verify vaults are in fact vaults
     let pool_def_data = PoolDefinition::try_from(&pool.account.data)
         .expect("Swap: AMM Program expects a valid Pool Definition Account");
@@ -28,6 +30,8 @@ pub fn swap(
         vault_b.account_id, pool_def_data.vault_b_id,
         "Vault B was not provided"
     );
+    assert!(pool_def_data.reserve_a != 0, "Reserves must be nonzero");
+    assert!(pool_def_data.reserve_b != 0, "Reserves must be nonzero");
 
     // fetch pool reserves
     // validates reserves is at least the vaults' balances
@@ -94,11 +98,33 @@ pub fn swap(
             panic!("AccountId is not a token type for the pool");
         };
 
+    let old_reserve_a = pool_def_data.reserve_a;
+    let old_reserve_b = pool_def_data.reserve_b;
+
+    let new_reserve_a = old_reserve_a
+        .checked_add(deposit_a)
+        .expect("Reserve A overflow on swap deposit")
+        .checked_sub(withdraw_a)
+        .expect("Reserve A underflow on swap withdrawal");
+    let new_reserve_b = old_reserve_b
+        .checked_add(deposit_b)
+        .expect("Reserve B overflow on swap deposit")
+        .checked_sub(withdraw_b)
+        .expect("Reserve B underflow on swap withdrawal");
+
+    let old_k = mul_u128_wide(old_reserve_a, old_reserve_b);
+    let new_k = mul_u128_wide(new_reserve_a, new_reserve_b);
+
+    assert!(
+        new_k >= old_k,
+        "Swap invariant violation: new k must be greater than or equal to old k"
+    );
+
     // Update pool account
     let mut pool_post = pool.account.clone();
     let pool_post_definition = PoolDefinition {
-        reserve_a: pool_def_data.reserve_a + deposit_a - withdraw_a,
-        reserve_b: pool_def_data.reserve_b + deposit_b - withdraw_b,
+        reserve_a: new_reserve_a,
+        reserve_b: new_reserve_b,
         ..pool_def_data
     };
 
@@ -130,8 +156,13 @@ fn swap_logic(
     // Compute withdraw amount
     // Maintains pool constant product
     // k = pool_def_data.reserve_a * pool_def_data.reserve_b;
-    let withdraw_amount = (reserve_withdraw_vault_amount * swap_amount_in)
-        / (reserve_deposit_vault_amount + swap_amount_in);
+    let withdraw_numerator = reserve_withdraw_vault_amount
+        .checked_mul(swap_amount_in)
+        .expect("Swap withdraw numerator overflow");
+    let withdraw_denominator = reserve_deposit_vault_amount
+        .checked_add(swap_amount_in)
+        .expect("Swap withdraw denominator overflow");
+    let withdraw_amount = withdraw_numerator / withdraw_denominator;
 
     // Slippage check
     assert!(
@@ -173,4 +204,9 @@ fn swap_logic(
     );
 
     (chained_calls, swap_amount_in, withdraw_amount)
+}
+
+fn mul_u128_wide(a: u128, b: u128) -> (u128, u128) {
+    let (lo, hi) = a.carrying_mul(b, 0);
+    (hi, lo)
 }

--- a/amm/src/tests.rs
+++ b/amm/src/tests.rs
@@ -1589,6 +1589,36 @@ fn test_call_swap_incorrect_token_type() {
     );
 }
 
+fn pool_with_reserves(reserve_a: u128, reserve_b: u128) -> AccountWithMetadata {
+    let mut pool = AccountWithMetadataForTests::pool_definition_init();
+    let mut pool_definition =
+        PoolDefinition::try_from(&pool.account.data).expect("Pool definition must be valid");
+
+    pool_definition.reserve_a = reserve_a;
+    pool_definition.reserve_b = reserve_b;
+    pool.account.data = Data::from(&pool_definition);
+
+    pool
+}
+
+fn vault_a_with_balance(balance: u128) -> AccountWithMetadata {
+    let mut vault = AccountWithMetadataForTests::vault_a_init();
+    vault.account.data = Data::from(&TokenHolding::Fungible {
+        definition_id: IdForTests::token_a_definition_id(),
+        balance,
+    });
+    vault
+}
+
+fn vault_b_with_balance(balance: u128) -> AccountWithMetadata {
+    let mut vault = AccountWithMetadataForTests::vault_b_init();
+    vault.account.data = Data::from(&TokenHolding::Fungible {
+        definition_id: IdForTests::token_b_definition_id(),
+        balance,
+    });
+    vault
+}
+
 #[should_panic(expected = "Vault A was not provided")]
 #[test]
 fn test_call_swap_vault_a_omitted() {
@@ -1615,6 +1645,51 @@ fn test_call_swap_vault_b_omitted() {
         AccountWithMetadataForTests::user_holding_b(),
         BalanceForTests::add_max_amount_a(),
         BalanceForTests::min_amount_out(),
+        IdForTests::token_a_definition_id(),
+    );
+}
+
+#[should_panic(expected = "Swap amount in should be nonzero")]
+#[test]
+fn test_call_swap_zero_amount_in() {
+    let _post_states = swap(
+        AccountWithMetadataForTests::pool_definition_init(),
+        AccountWithMetadataForTests::vault_a_init(),
+        AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::user_holding_a(),
+        AccountWithMetadataForTests::user_holding_b(),
+        0,
+        0,
+        IdForTests::token_a_definition_id(),
+    );
+}
+
+#[should_panic(expected = "Reserves must be nonzero")]
+#[test]
+fn test_call_swap_reserves_zero_1() {
+    let _post_states = swap(
+        AccountWithMetadataForTests::pool_definition_init_reserve_a_zero(),
+        AccountWithMetadataForTests::vault_a_init(),
+        AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::user_holding_a(),
+        AccountWithMetadataForTests::user_holding_b(),
+        1,
+        0,
+        IdForTests::token_a_definition_id(),
+    );
+}
+
+#[should_panic(expected = "Reserves must be nonzero")]
+#[test]
+fn test_call_swap_reserves_zero_2() {
+    let _post_states = swap(
+        AccountWithMetadataForTests::pool_definition_init_reserve_b_zero(),
+        AccountWithMetadataForTests::vault_a_init(),
+        AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::user_holding_a(),
+        AccountWithMetadataForTests::user_holding_b(),
+        1,
+        0,
         IdForTests::token_a_definition_id(),
     );
 }
@@ -1649,6 +1724,36 @@ fn test_call_swap_reserves_vault_mismatch_2() {
     );
 }
 
+#[should_panic(expected = "Swap withdraw numerator overflow")]
+#[test]
+fn test_call_swap_withdraw_numerator_overflow() {
+    let _post_states = swap(
+        pool_with_reserves(1, u128::MAX),
+        vault_a_with_balance(1),
+        vault_b_with_balance(u128::MAX),
+        AccountWithMetadataForTests::user_holding_a(),
+        AccountWithMetadataForTests::user_holding_b(),
+        2,
+        0,
+        IdForTests::token_a_definition_id(),
+    );
+}
+
+#[should_panic(expected = "Swap withdraw denominator overflow")]
+#[test]
+fn test_call_swap_withdraw_denominator_overflow() {
+    let _post_states = swap(
+        pool_with_reserves(u128::MAX, 10),
+        vault_a_with_balance(u128::MAX),
+        vault_b_with_balance(10),
+        AccountWithMetadataForTests::user_holding_a(),
+        AccountWithMetadataForTests::user_holding_b(),
+        1,
+        0,
+        IdForTests::token_a_definition_id(),
+    );
+}
+
 #[should_panic(expected = "Pool is inactive")]
 #[test]
 fn test_call_swap_ianctive() {
@@ -1677,6 +1782,36 @@ fn test_call_swap_below_min_out() {
         BalanceForTests::min_amount_out(),
         IdForTests::token_a_definition_id(),
     );
+}
+
+#[test]
+fn test_call_swap_widened_k_boundary() {
+    let old_reserve_a = u128::MAX - 2;
+    let old_reserve_b = u128::MAX - 1;
+
+    assert!(old_reserve_a.checked_mul(old_reserve_b).is_none());
+
+    let (post_states, _chained_calls) = swap(
+        pool_with_reserves(old_reserve_a, old_reserve_b),
+        vault_a_with_balance(old_reserve_a),
+        vault_b_with_balance(old_reserve_b),
+        AccountWithMetadataForTests::user_holding_a(),
+        AccountWithMetadataForTests::user_holding_b(),
+        1,
+        0,
+        IdForTests::token_a_definition_id(),
+    );
+
+    let pool_post = post_states[0].clone();
+    let pool_post_definition = PoolDefinition::try_from(&pool_post.account().data)
+        .expect("Pool post-state must contain a valid definition");
+
+    assert_eq!(pool_post_definition.reserve_a, u128::MAX - 1);
+    assert_eq!(pool_post_definition.reserve_b, u128::MAX - 2);
+    assert!(pool_post_definition
+        .reserve_a
+        .checked_mul(pool_post_definition.reserve_b)
+        .is_none());
 }
 
 #[test]


### PR DESCRIPTION
## 🎯 Purpose
Fixes #5.
Migrate the issue-scoped post-swap invariant hardening from `logos-execution-zone` [PR 373](https://github.com/logos-blockchain/logos-execution-zone/pull/373) into `lez-programs`, adapted to this repository's current AMM layout.
- Reject zero-input swaps and invalid zero-reserve pools before swap math runs.
- Replace unchecked swap math and reserve updates with checked arithmetic so arithmetic hazards fail closed.
- Enforce `new_k >= old_k` with widened multiplication and add focused AMM regression coverage.

## ⚙️ What Changed
- [x] Add early `swap_amount_in > 0` and `reserve_a != 0` / `reserve_b != 0` guards in `amm/src/swap.rs`.
- [x] Replace unchecked withdraw numerator/denominator math and reserve updates with checked operations and explicit failure messages.
- [x] Add a local `mul_u128_wide` helper backed by `u128::carrying_mul` so old and new `k` can be compared without `u128` overflow.
- [x] Add AMM unit-test helpers and regression cases for zero input, zero reserves, numerator overflow, denominator overflow, and the widened-`k` boundary.
- [x] Keep the migration scoped to `amm/src/swap.rs` and `amm/src/tests.rs`; no guest, core, or IDL changes are required.

## 🔎 Migration Notes
- Ports only the final issue-5 behavior from old PR 373, not the unrelated sync/recover/minimum-liquidity work that also lived on that old branch.
- The original upstream PR was carrying commits from other PR work as well, and those extra changes were intentionally not reintroduced here.
- The diff against this repository's `main` is scoped to 2 files in the AMM crate with 175 insertions and 4 deletions.
- The `Swap` instruction interface stays unchanged, so there is no IDL regeneration or guest-entrypoint update in this PR.

## 🔎 Review Focus
- Swap now fails before any pricing math starts for zero-input and zero-reserve states.
- Checked reserve updates and full-width `k` comparison prevent silent arithmetic wraparound in both the withdraw math and the post-swap invariant check.
- The added tests cover both the new rejection paths and the large-value boundary where `reserve_a * reserve_b` exceeds `u128`.

## 🧪 How to Test
1. `cargo check -p amm_program`
2. `RISC0_DEV_MODE=1 cargo test -p amm_program --lib`
3. `RISC0_DEV_MODE=1 cargo test -p integration_tests amm_swap`

## 🔗 Dependencies
None.

## 📋 PR Completion Checklist
- [x] Port the issue-5 swap hardening from old PR 373 into `lez-programs`
- [x] Add regression coverage for the new failure and boundary cases
- [x] Leave public AMM interfaces unchanged
