### PR TITLE
feat: enhance remove liquidity function to handle surplus balances

### DIFF
--- a/amm/src/remove.rs
+++ b/amm/src/remove.rs
@@ -56,7 +56,41 @@ pub fn remove_liquidity(
         "Minimum withdraw amount must be nonzero"
     );
 
-    // 2. Compute withdrawal amounts
+    // 2. Read live vault balances and compute withdrawal amounts
+    let vault_a_token_holding = token_core::TokenHolding::try_from(&vault_a.account.data)
+        .expect("Remove liquidity: AMM Program expects a valid Token Holding Account for Vault A");
+    let token_core::TokenHolding::Fungible {
+        definition_id: _,
+        balance: vault_a_balance,
+    } = vault_a_token_holding
+    else {
+        panic!(
+            "Remove liquidity: AMM Program expects a valid Fungible Token Holding Account for Vault A"
+        );
+    };
+
+    assert!(
+        vault_a_balance >= pool_def_data.reserve_a,
+        "Reserve for Token A exceeds vault balance"
+    );
+
+    let vault_b_token_holding = token_core::TokenHolding::try_from(&vault_b.account.data)
+        .expect("Remove liquidity: AMM Program expects a valid Token Holding Account for Vault B");
+    let token_core::TokenHolding::Fungible {
+        definition_id: _,
+        balance: vault_b_balance,
+    } = vault_b_token_holding
+    else {
+        panic!(
+            "Remove liquidity: AMM Program expects a valid Fungible Token Holding Account for Vault B"
+        );
+    };
+
+    assert!(
+        vault_b_balance >= pool_def_data.reserve_b,
+        "Reserve for Token B exceeds vault balance"
+    );
+
     let user_holding_lp_data = token_core::TokenHolding::try_from(&user_holding_lp.account.data)
         .expect("Remove liquidity: AMM Program expects a valid Token Account for liquidity token");
     let token_core::TokenHolding::Fungible {
@@ -79,33 +113,36 @@ pub fn remove_liquidity(
         "Invalid liquidity account provided"
     );
 
-    let withdraw_amount_a =
+    let reserve_withdraw_amount_a =
         (pool_def_data.reserve_a * remove_liquidity_amount) / pool_def_data.liquidity_pool_supply;
-    let withdraw_amount_b =
+    let reserve_withdraw_amount_b =
         (pool_def_data.reserve_b * remove_liquidity_amount) / pool_def_data.liquidity_pool_supply;
+    let actual_withdraw_amount_a =
+        (vault_a_balance * remove_liquidity_amount) / pool_def_data.liquidity_pool_supply;
+    let actual_withdraw_amount_b =
+        (vault_b_balance * remove_liquidity_amount) / pool_def_data.liquidity_pool_supply;
 
     // 3. Validate and slippage check
     assert!(
-        withdraw_amount_a >= min_amount_to_remove_token_a,
+        actual_withdraw_amount_a >= min_amount_to_remove_token_a,
         "Insufficient minimal withdraw amount (Token A) provided for liquidity amount"
     );
     assert!(
-        withdraw_amount_b >= min_amount_to_remove_token_b,
+        actual_withdraw_amount_b >= min_amount_to_remove_token_b,
         "Insufficient minimal withdraw amount (Token B) provided for liquidity amount"
     );
 
-    // 4. Calculate LP to reduce cap by
-    let delta_lp: u128 = (pool_def_data.liquidity_pool_supply * remove_liquidity_amount)
-        / pool_def_data.liquidity_pool_supply;
+    // 4. Burn exactly the requested LP amount.
+    let burn_amount_lp = remove_liquidity_amount;
 
-    let active: bool = pool_def_data.liquidity_pool_supply - delta_lp != 0;
+    let active: bool = pool_def_data.liquidity_pool_supply - burn_amount_lp != 0;
 
     // 5. Update pool account
     let mut pool_post = pool.account.clone();
     let pool_post_definition = PoolDefinition {
-        liquidity_pool_supply: pool_def_data.liquidity_pool_supply - delta_lp,
-        reserve_a: pool_def_data.reserve_a - withdraw_amount_a,
-        reserve_b: pool_def_data.reserve_b - withdraw_amount_b,
+        liquidity_pool_supply: pool_def_data.liquidity_pool_supply - burn_amount_lp,
+        reserve_a: pool_def_data.reserve_a - reserve_withdraw_amount_a,
+        reserve_b: pool_def_data.reserve_b - reserve_withdraw_amount_b,
         active,
         ..pool_def_data.clone()
     };
@@ -119,7 +156,7 @@ pub fn remove_liquidity(
         token_program_id,
         vec![running_vault_a, user_holding_a.clone()],
         &token_core::Instruction::Transfer {
-            amount_to_transfer: withdraw_amount_a,
+            amount_to_transfer: actual_withdraw_amount_a,
         },
     )
     .with_pda_seeds(vec![compute_vault_pda_seed(
@@ -131,7 +168,7 @@ pub fn remove_liquidity(
         token_program_id,
         vec![running_vault_b, user_holding_b.clone()],
         &token_core::Instruction::Transfer {
-            amount_to_transfer: withdraw_amount_b,
+            amount_to_transfer: actual_withdraw_amount_b,
         },
     )
     .with_pda_seeds(vec![compute_vault_pda_seed(
@@ -145,7 +182,7 @@ pub fn remove_liquidity(
         token_program_id,
         vec![pool_definition_lp_auth, user_holding_lp.clone()],
         &token_core::Instruction::Burn {
-            amount_to_burn: delta_lp,
+            amount_to_burn: burn_amount_lp,
         },
     )
     .with_pda_seeds(vec![compute_liquidity_token_pda_seed(pool.account_id)]);

--- a/amm/src/tests.rs
+++ b/amm/src/tests.rs
@@ -153,6 +153,30 @@ impl BalanceForTests {
     fn vault_b_remove_successful() -> u128 {
         430
     }
+
+    fn remove_actual_b_successful() -> u128 {
+        70
+    }
+
+    fn vault_a_balance_with_surplus() -> u128 {
+        1_100
+    }
+
+    fn vault_b_balance_with_surplus() -> u128 {
+        600
+    }
+
+    fn remove_actual_a_with_surplus() -> u128 {
+        155
+    }
+
+    fn remove_actual_b_with_surplus() -> u128 {
+        84
+    }
+
+    fn remove_min_amount_b_surplus() -> u128 {
+        80
+    }
 }
 
 impl ChainedCallForTests {
@@ -290,7 +314,41 @@ impl ChainedCallForTests {
             TOKEN_PROGRAM_ID,
             vec![vault_b_auth, AccountWithMetadataForTests::user_holding_b()],
             &token_core::Instruction::Transfer {
-                amount_to_transfer: 70,
+                amount_to_transfer: BalanceForTests::remove_actual_b_successful(),
+            },
+        )
+        .with_pda_seeds(vec![compute_vault_pda_seed(
+            IdForTests::pool_definition_id(),
+            IdForTests::token_b_definition_id(),
+        )])
+    }
+
+    fn cc_remove_token_a_with_surplus() -> ChainedCall {
+        let mut vault_a_auth = AccountWithMetadataForTests::vault_a_with_surplus();
+        vault_a_auth.is_authorized = true;
+
+        ChainedCall::new(
+            TOKEN_PROGRAM_ID,
+            vec![vault_a_auth, AccountWithMetadataForTests::user_holding_a()],
+            &token_core::Instruction::Transfer {
+                amount_to_transfer: BalanceForTests::remove_actual_a_with_surplus(),
+            },
+        )
+        .with_pda_seeds(vec![compute_vault_pda_seed(
+            IdForTests::pool_definition_id(),
+            IdForTests::token_a_definition_id(),
+        )])
+    }
+
+    fn cc_remove_token_b_with_surplus() -> ChainedCall {
+        let mut vault_b_auth = AccountWithMetadataForTests::vault_b_with_surplus();
+        vault_b_auth.is_authorized = true;
+
+        ChainedCall::new(
+            TOKEN_PROGRAM_ID,
+            vec![vault_b_auth, AccountWithMetadataForTests::user_holding_b()],
+            &token_core::Instruction::Transfer {
+                amount_to_transfer: BalanceForTests::remove_actual_b_with_surplus(),
             },
         )
         .with_pda_seeds(vec![compute_vault_pda_seed(
@@ -468,6 +526,38 @@ impl AccountWithMetadataForTests {
                 data: Data::from(&TokenHolding::Fungible {
                     definition_id: IdForTests::token_b_definition_id(),
                     balance: BalanceForTests::vault_b_reserve_init(),
+                }),
+                nonce: Nonce(0),
+            },
+            is_authorized: true,
+            account_id: IdForTests::vault_b_id(),
+        }
+    }
+
+    fn vault_a_with_surplus() -> AccountWithMetadata {
+        AccountWithMetadata {
+            account: Account {
+                program_owner: TOKEN_PROGRAM_ID,
+                balance: 0u128,
+                data: Data::from(&TokenHolding::Fungible {
+                    definition_id: IdForTests::token_a_definition_id(),
+                    balance: BalanceForTests::vault_a_balance_with_surplus(),
+                }),
+                nonce: Nonce(0),
+            },
+            is_authorized: true,
+            account_id: IdForTests::vault_a_id(),
+        }
+    }
+
+    fn vault_b_with_surplus() -> AccountWithMetadata {
+        AccountWithMetadata {
+            account: Account {
+                program_owner: TOKEN_PROGRAM_ID,
+                balance: 0u128,
+                data: Data::from(&TokenHolding::Fungible {
+                    definition_id: IdForTests::token_b_definition_id(),
+                    balance: BalanceForTests::vault_b_balance_with_surplus(),
                 }),
                 nonce: Nonce(0),
             },
@@ -1375,6 +1465,40 @@ fn test_call_remove_liquidity_min_bal_zero_2() {
     );
 }
 
+#[should_panic(expected = "Reserve for Token A exceeds vault balance")]
+#[test]
+fn test_call_remove_liquidity_reserves_vault_mismatch_1() {
+    let _post_states = remove_liquidity(
+        AccountWithMetadataForTests::pool_definition_init(),
+        AccountWithMetadataForTests::vault_a_init_low(),
+        AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::pool_lp_init(),
+        AccountWithMetadataForTests::user_holding_a(),
+        AccountWithMetadataForTests::user_holding_b(),
+        AccountWithMetadataForTests::user_holding_lp_init(),
+        NonZero::new(BalanceForTests::remove_amount_lp()).unwrap(),
+        BalanceForTests::remove_min_amount_a(),
+        BalanceForTests::remove_min_amount_b(),
+    );
+}
+
+#[should_panic(expected = "Reserve for Token B exceeds vault balance")]
+#[test]
+fn test_call_remove_liquidity_reserves_vault_mismatch_2() {
+    let _post_states = remove_liquidity(
+        AccountWithMetadataForTests::pool_definition_init(),
+        AccountWithMetadataForTests::vault_a_init(),
+        AccountWithMetadataForTests::vault_b_init_low(),
+        AccountWithMetadataForTests::pool_lp_init(),
+        AccountWithMetadataForTests::user_holding_a(),
+        AccountWithMetadataForTests::user_holding_b(),
+        AccountWithMetadataForTests::user_holding_lp_init(),
+        NonZero::new(BalanceForTests::remove_amount_lp()).unwrap(),
+        BalanceForTests::remove_min_amount_a(),
+        BalanceForTests::remove_min_amount_b(),
+    );
+}
+
 #[test]
 fn test_call_remove_liquidity_chained_call_successful() {
     let (post_states, chained_calls) = remove_liquidity(
@@ -1403,6 +1527,37 @@ fn test_call_remove_liquidity_chained_call_successful() {
 
     assert!(chained_call_a == ChainedCallForTests::cc_remove_token_a());
     assert!(chained_call_b == ChainedCallForTests::cc_remove_token_b());
+    assert!(chained_call_lp == ChainedCallForTests::cc_remove_pool_lp());
+}
+
+#[test]
+fn test_call_remove_liquidity_chained_call_with_vault_surplus_successful() {
+    let (post_states, chained_calls) = remove_liquidity(
+        AccountWithMetadataForTests::pool_definition_init(),
+        AccountWithMetadataForTests::vault_a_with_surplus(),
+        AccountWithMetadataForTests::vault_b_with_surplus(),
+        AccountWithMetadataForTests::pool_lp_init(),
+        AccountWithMetadataForTests::user_holding_a(),
+        AccountWithMetadataForTests::user_holding_b(),
+        AccountWithMetadataForTests::user_holding_lp_init(),
+        NonZero::new(BalanceForTests::remove_amount_lp()).unwrap(),
+        BalanceForTests::remove_min_amount_a(),
+        BalanceForTests::remove_min_amount_b_surplus(),
+    );
+
+    let pool_post = post_states[0].clone();
+
+    assert!(
+        AccountWithMetadataForTests::pool_definition_remove_successful().account
+            == *pool_post.account()
+    );
+
+    let chained_call_lp = chained_calls[0].clone();
+    let chained_call_b = chained_calls[1].clone();
+    let chained_call_a = chained_calls[2].clone();
+
+    assert!(chained_call_a == ChainedCallForTests::cc_remove_token_a_with_surplus());
+    assert!(chained_call_b == ChainedCallForTests::cc_remove_token_b_with_surplus());
     assert!(chained_call_lp == ChainedCallForTests::cc_remove_pool_lp());
 }
 

--- a/integration_tests/tests/amm.rs
+++ b/integration_tests/tests/amm.rs
@@ -132,6 +132,14 @@ impl Balances {
         500
     }
 
+    fn remove_min_a_with_surplus() -> u128 {
+        1_100
+    }
+
+    fn remove_min_b_with_surplus() -> u128 {
+        550
+    }
+
     fn add_min_lp() -> u128 {
         1_000
     }
@@ -216,12 +224,36 @@ impl Balances {
         2_000
     }
 
+    fn vault_a_with_surplus() -> u128 {
+        5_500
+    }
+
+    fn vault_b_with_surplus() -> u128 {
+        2_750
+    }
+
+    fn vault_a_remove_with_surplus() -> u128 {
+        4_400
+    }
+
+    fn vault_b_remove_with_surplus() -> u128 {
+        2_200
+    }
+
     fn user_a_remove() -> u128 {
         11_000
     }
 
     fn user_b_remove() -> u128 {
         10_500
+    }
+
+    fn user_a_remove_with_surplus() -> u128 {
+        11_100
+    }
+
+    fn user_b_remove_with_surplus() -> u128 {
+        10_550
     }
 
     fn user_lp_remove() -> u128 {
@@ -348,6 +380,30 @@ impl Accounts {
             data: Data::from(&TokenHolding::Fungible {
                 definition_id: Ids::token_b_definition(),
                 balance: Balances::vault_b_init(),
+            }),
+            nonce: Nonce(0),
+        }
+    }
+
+    fn vault_a_with_surplus() -> Account {
+        Account {
+            program_owner: Ids::token_program(),
+            balance: 0_u128,
+            data: Data::from(&TokenHolding::Fungible {
+                definition_id: Ids::token_a_definition(),
+                balance: Balances::vault_a_with_surplus(),
+            }),
+            nonce: Nonce(0),
+        }
+    }
+
+    fn vault_b_with_surplus() -> Account {
+        Account {
+            program_owner: Ids::token_program(),
+            balance: 0_u128,
+            data: Data::from(&TokenHolding::Fungible {
+                definition_id: Ids::token_b_definition(),
+                balance: Balances::vault_b_with_surplus(),
             }),
             nonce: Nonce(0),
         }
@@ -640,6 +696,30 @@ impl Accounts {
         }
     }
 
+    fn vault_a_remove_with_surplus() -> Account {
+        Account {
+            program_owner: Ids::token_program(),
+            balance: 0_u128,
+            data: Data::from(&TokenHolding::Fungible {
+                definition_id: Ids::token_a_definition(),
+                balance: Balances::vault_a_remove_with_surplus(),
+            }),
+            nonce: Nonce(0),
+        }
+    }
+
+    fn vault_b_remove_with_surplus() -> Account {
+        Account {
+            program_owner: Ids::token_program(),
+            balance: 0_u128,
+            data: Data::from(&TokenHolding::Fungible {
+                definition_id: Ids::token_b_definition(),
+                balance: Balances::vault_b_remove_with_surplus(),
+            }),
+            nonce: Nonce(0),
+        }
+    }
+
     fn user_a_holding_remove() -> Account {
         Account {
             program_owner: Ids::token_program(),
@@ -659,6 +739,30 @@ impl Accounts {
             data: Data::from(&TokenHolding::Fungible {
                 definition_id: Ids::token_b_definition(),
                 balance: Balances::user_b_remove(),
+            }),
+            nonce: Nonce(0),
+        }
+    }
+
+    fn user_a_holding_remove_with_surplus() -> Account {
+        Account {
+            program_owner: Ids::token_program(),
+            balance: 0_u128,
+            data: Data::from(&TokenHolding::Fungible {
+                definition_id: Ids::token_a_definition(),
+                balance: Balances::user_a_remove_with_surplus(),
+            }),
+            nonce: Nonce(0),
+        }
+    }
+
+    fn user_b_holding_remove_with_surplus() -> Account {
+        Account {
+            program_owner: Ids::token_program(),
+            balance: 0_u128,
+            data: Data::from(&TokenHolding::Fungible {
+                definition_id: Ids::token_b_definition(),
+                balance: Balances::user_b_remove_with_surplus(),
             }),
             nonce: Nonce(0),
         }
@@ -939,6 +1043,69 @@ fn amm_remove_liquidity() {
     assert_eq!(
         state.get_account_by_id(Ids::user_b()),
         Accounts::user_b_holding_remove()
+    );
+    assert_eq!(
+        state.get_account_by_id(Ids::user_lp()),
+        Accounts::user_lp_holding_remove()
+    );
+}
+
+#[test]
+fn amm_remove_liquidity_with_surplus() {
+    let mut state = state_for_amm_tests();
+    state.force_insert_account(Ids::vault_a(), Accounts::vault_a_with_surplus());
+    state.force_insert_account(Ids::vault_b(), Accounts::vault_b_with_surplus());
+
+    let instruction = amm_core::Instruction::RemoveLiquidity {
+        remove_liquidity_amount: Balances::remove_lp(),
+        min_amount_to_remove_token_a: Balances::remove_min_a_with_surplus(),
+        min_amount_to_remove_token_b: Balances::remove_min_b_with_surplus(),
+    };
+
+    let message = public_transaction::Message::try_new(
+        Ids::amm_program(),
+        vec![
+            Ids::pool_definition(),
+            Ids::vault_a(),
+            Ids::vault_b(),
+            Ids::token_lp_definition(),
+            Ids::user_a(),
+            Ids::user_b(),
+            Ids::user_lp(),
+        ],
+        vec![Nonce(0)],
+        instruction,
+    )
+    .unwrap();
+
+    let witness_set = public_transaction::WitnessSet::for_message(&message, &[&Keys::user_lp()]);
+
+    let tx = PublicTransaction::new(message, witness_set);
+    state.transition_from_public_transaction(&tx, 0).unwrap();
+
+    assert_eq!(
+        state.get_account_by_id(Ids::pool_definition()),
+        Accounts::pool_definition_remove()
+    );
+    assert_eq!(
+        state.get_account_by_id(Ids::vault_a()),
+        Accounts::vault_a_remove_with_surplus()
+    );
+    assert_eq!(
+        state.get_account_by_id(Ids::vault_b()),
+        Accounts::vault_b_remove_with_surplus()
+    );
+    assert_eq!(
+        state.get_account_by_id(Ids::token_lp_definition()),
+        Accounts::token_lp_definition_remove()
+    );
+    assert_eq!(
+        state.get_account_by_id(Ids::user_a()),
+        Accounts::user_a_holding_remove_with_surplus()
+    );
+    assert_eq!(
+        state.get_account_by_id(Ids::user_b()),
+        Accounts::user_b_holding_remove_with_surplus()
     );
     assert_eq!(
         state.get_account_by_id(Ids::user_lp()),


### PR DESCRIPTION
## Summary

- update `remove_liquidity` to compute user payouts from the live vault balances while keeping pool reserve bookkeeping based on tracked reserves
- keep LP burn semantics unchanged by burning exactly the requested LP amount instead of the previous redundant `delta_lp` identity
- add unit and integration coverage for fee-surplus exits, actual-payout slippage checks, and reserve-vs-vault mismatch rejection

Fixes #15 
Replaces https://github.com/logos-blockchain/logos-execution-zone/pull/420

## Testing

- `cargo +1.94.0 test -p amm_program remove_liquidity`
- `RISC0_DEV_MODE=1 cargo +1.94.0 test -p integration_tests amm_remove_liquidity`
- `cargo +nightly fmt --all -- --check`
- `taplo fmt --check .`
- `RISC0_SKIP_BUILD=1 cargo +1.94.0 clippy --workspace --all-targets -- -D warnings`
- `RISC0_DEV_MODE=1 cargo +1.94.0 test --workspace --exclude integration_tests`
- `RISC0_DEV_MODE=1 cargo +1.94.0 test -p integration_tests`

## Notes

- remove-liquidity transfers now use each LP's pro-rata share of the actual vault holdings, so accumulated fee surplus is paid out on exit
- pool `reserve_a` and `reserve_b` remain reserve-based after exit, which preserves any remaining surplus as `vault_balance - reserve` for the LPs who stay in the pool
- remove-liquidity now rejects invalid states where a vault balance falls below its tracked reserve, matching the existing add/swap safety checks
- there are no `Instruction`, IDL, guest entrypoint, or account-schema changes in this PR
