### PR TITLE
feat(amm): add configurable fee tiers

### DIFF
--- a/amm/amm-idl.json
+++ b/amm/amm-idl.json
@@ -58,6 +58,10 @@
           "type": "u128"
         },
         {
+          "name": "fees",
+          "type": "u128"
+        },
+        {
           "name": "amm_program_id",
           "type": "program_id"
         }

--- a/amm/core/src/lib.rs
+++ b/amm/core/src/lib.rs
@@ -23,6 +23,7 @@ pub enum Instruction {
     NewDefinition {
         token_a_amount: u128,
         token_b_amount: u128,
+        fees: u128,
         amm_program_id: ProgramId,
     },
 
@@ -85,12 +86,32 @@ pub struct PoolDefinition {
     pub liquidity_pool_supply: u128,
     pub reserve_a: u128,
     pub reserve_b: u128,
-    /// Fees are currently not used
+    /// Fee tier in basis points.
     pub fees: u128,
     /// A pool becomes inactive (active = false)
     /// once all of its liquidity has been removed (e.g., reserves are emptied and
     /// liquidity_pool_supply = 0)
     pub active: bool,
+}
+
+pub const FEE_BPS_DENOMINATOR: u128 = 10_000;
+pub const FEE_TIER_BPS_1: u128 = 1;
+pub const FEE_TIER_BPS_5: u128 = 5;
+pub const FEE_TIER_BPS_30: u128 = 30;
+pub const FEE_TIER_BPS_100: u128 = 100;
+
+pub fn is_supported_fee_tier(fees: u128) -> bool {
+    matches!(
+        fees,
+        FEE_TIER_BPS_1 | FEE_TIER_BPS_5 | FEE_TIER_BPS_30 | FEE_TIER_BPS_100
+    )
+}
+
+pub fn assert_supported_fee_tier(fees: u128) {
+    assert!(
+        is_supported_fee_tier(fees),
+        "Fee tier must be one of 1, 5, 30, or 100 basis points"
+    );
 }
 
 impl TryFrom<&Data> for PoolDefinition {

--- a/amm/methods/guest/src/bin/amm.rs
+++ b/amm/methods/guest/src/bin/amm.rs
@@ -27,6 +27,7 @@ mod amm {
         user_holding_lp: AccountWithMetadata,
         token_a_amount: u128,
         token_b_amount: u128,
+        fees: u128,
         amm_program_id: ProgramId,
     ) -> SpelResult {
         let (post_states, chained_calls) = amm_program::new_definition::new_definition(
@@ -39,6 +40,7 @@ mod amm {
             user_holding_lp,
             NonZeroU128::new(token_a_amount).expect("token_a_amount must be nonzero"),
             NonZeroU128::new(token_b_amount).expect("token_b_amount must be nonzero"),
+            fees,
             amm_program_id,
         );
         Ok(SpelOutput::with_chained_calls(post_states, chained_calls))

--- a/amm/src/add.rs
+++ b/amm/src/add.rs
@@ -1,6 +1,6 @@
 use std::num::NonZeroU128;
 
-use amm_core::{compute_liquidity_token_pda_seed, PoolDefinition};
+use amm_core::{assert_supported_fee_tier, compute_liquidity_token_pda_seed, PoolDefinition};
 use nssa_core::{
     account::{AccountWithMetadata, Data},
     program::{AccountPostState, ChainedCall},
@@ -22,6 +22,7 @@ pub fn add_liquidity(
     // 1. Fetch Pool state
     let pool_def_data = PoolDefinition::try_from(&pool.account.data)
         .expect("Add liquidity: AMM Program expects valid Pool Definition Account");
+    assert_supported_fee_tier(pool_def_data.fees);
 
     assert_eq!(
         vault_a.account_id, pool_def_data.vault_a_id,

--- a/amm/src/new_definition.rs
+++ b/amm/src/new_definition.rs
@@ -1,8 +1,8 @@
 use std::num::NonZeroU128;
 
 use amm_core::{
-    compute_liquidity_token_pda, compute_liquidity_token_pda_seed, compute_pool_pda,
-    compute_vault_pda, PoolDefinition,
+    assert_supported_fee_tier, compute_liquidity_token_pda, compute_liquidity_token_pda_seed,
+    compute_pool_pda, compute_vault_pda, PoolDefinition,
 };
 use nssa_core::{
     account::{Account, AccountWithMetadata, Data},
@@ -20,6 +20,7 @@ pub fn new_definition(
     user_holding_lp: AccountWithMetadata,
     token_a_amount: NonZeroU128,
     token_b_amount: NonZeroU128,
+    fees: u128,
     amm_program_id: ProgramId,
 ) -> (Vec<AccountPostState>, Vec<ChainedCall>) {
     // Verify token_a and token_b are different
@@ -61,6 +62,7 @@ pub fn new_definition(
         compute_liquidity_token_pda(amm_program_id, pool.account_id),
         "Liquidity pool Token Definition Account ID does not match PDA"
     );
+    assert_supported_fee_tier(fees);
 
     // TODO: return here
     // Verify that Pool Account is not active
@@ -90,7 +92,7 @@ pub fn new_definition(
         liquidity_pool_supply: initial_lp,
         reserve_a: token_a_amount.into(),
         reserve_b: token_b_amount.into(),
-        fees: 0u128, // TODO: we assume all fees are 0 for now.
+        fees,
         active: true,
     };
 

--- a/amm/src/remove.rs
+++ b/amm/src/remove.rs
@@ -1,6 +1,9 @@
 use std::num::NonZeroU128;
 
-use amm_core::{compute_liquidity_token_pda_seed, compute_vault_pda_seed, PoolDefinition};
+use amm_core::{
+    assert_supported_fee_tier, compute_liquidity_token_pda_seed, compute_vault_pda_seed,
+    PoolDefinition,
+};
 use nssa_core::{
     account::{AccountWithMetadata, Data},
     program::{AccountPostState, ChainedCall},
@@ -24,6 +27,7 @@ pub fn remove_liquidity(
     // 1. Fetch Pool state
     let pool_def_data = PoolDefinition::try_from(&pool.account.data)
         .expect("Remove liquidity: AMM Program expects a valid Pool Definition Account");
+    assert_supported_fee_tier(pool_def_data.fees);
 
     assert!(pool_def_data.active, "Pool is inactive");
     assert_eq!(

--- a/amm/src/swap.rs
+++ b/amm/src/swap.rs
@@ -1,3 +1,4 @@
+use amm_core::assert_supported_fee_tier;
 pub use amm_core::{compute_liquidity_token_pda_seed, compute_vault_pda_seed, PoolDefinition};
 use nssa_core::{
     account::{AccountId, AccountWithMetadata, Data},
@@ -18,6 +19,7 @@ pub fn swap(
     // Verify vaults are in fact vaults
     let pool_def_data = PoolDefinition::try_from(&pool.account.data)
         .expect("Swap: AMM Program expects a valid Pool Definition Account");
+    assert_supported_fee_tier(pool_def_data.fees);
 
     assert!(pool_def_data.active, "Pool is inactive");
     assert_eq!(

--- a/amm/src/tests.rs
+++ b/amm/src/tests.rs
@@ -1678,6 +1678,26 @@ fn test_call_swap_ianctive() {
     );
 }
 
+#[should_panic(expected = "Fee tier must be one of 1, 5, 30, or 100 basis points")]
+#[test]
+fn test_call_swap_rejects_unsupported_fee_tier() {
+    let mut pool = AccountWithMetadataForTests::pool_definition_init();
+    let mut pool_def = PoolDefinition::try_from(&pool.account.data).unwrap();
+    pool_def.fees = 2;
+    pool.account.data = Data::from(&pool_def);
+
+    let _post_states = swap(
+        pool,
+        AccountWithMetadataForTests::vault_a_init(),
+        AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::user_holding_a(),
+        AccountWithMetadataForTests::user_holding_b(),
+        BalanceForTests::add_max_amount_a(),
+        BalanceForTests::add_max_amount_a_low(),
+        IdForTests::token_a_definition_id(),
+    );
+}
+
 #[should_panic(expected = "Withdraw amount is less than minimal amount out")]
 #[test]
 fn test_call_swap_below_min_out() {

--- a/amm/src/tests.rs
+++ b/amm/src/tests.rs
@@ -4,7 +4,8 @@ use std::num::NonZero;
 
 use amm_core::{
     compute_liquidity_token_pda, compute_liquidity_token_pda_seed, compute_pool_pda,
-    compute_vault_pda, compute_vault_pda_seed, PoolDefinition,
+    compute_vault_pda, compute_vault_pda_seed, PoolDefinition, FEE_TIER_BPS_1, FEE_TIER_BPS_100,
+    FEE_TIER_BPS_30, FEE_TIER_BPS_5,
 };
 use nssa_core::{
     account::{Account, AccountId, AccountWithMetadata, Data, Nonce},
@@ -25,6 +26,10 @@ struct IdForTests;
 struct AccountWithMetadataForTests;
 
 impl BalanceForTests {
+    fn fee_tier() -> u128 {
+        FEE_TIER_BPS_30
+    }
+
     fn vault_a_reserve_init() -> u128 {
         1_000
     }
@@ -652,7 +657,7 @@ impl AccountWithMetadataForTests {
                     liquidity_pool_supply: BalanceForTests::lp_supply_init(),
                     reserve_a: BalanceForTests::vault_a_reserve_init(),
                     reserve_b: BalanceForTests::vault_b_reserve_init(),
-                    fees: 0u128,
+                    fees: BalanceForTests::fee_tier(),
                     active: true,
                 }),
                 nonce: Nonce(0),
@@ -676,7 +681,7 @@ impl AccountWithMetadataForTests {
                     liquidity_pool_supply: BalanceForTests::lp_supply_init(),
                     reserve_a: 0,
                     reserve_b: BalanceForTests::vault_b_reserve_init(),
-                    fees: 0u128,
+                    fees: BalanceForTests::fee_tier(),
                     active: true,
                 }),
                 nonce: Nonce(0),
@@ -700,7 +705,7 @@ impl AccountWithMetadataForTests {
                     liquidity_pool_supply: BalanceForTests::lp_supply_init(),
                     reserve_a: BalanceForTests::vault_a_reserve_init(),
                     reserve_b: 0,
-                    fees: 0u128,
+                    fees: BalanceForTests::fee_tier(),
                     active: true,
                 }),
                 nonce: Nonce(0),
@@ -724,7 +729,7 @@ impl AccountWithMetadataForTests {
                     liquidity_pool_supply: BalanceForTests::vault_a_reserve_low(),
                     reserve_a: BalanceForTests::vault_a_reserve_low(),
                     reserve_b: BalanceForTests::vault_b_reserve_high(),
-                    fees: 0u128,
+                    fees: BalanceForTests::fee_tier(),
                     active: true,
                 }),
                 nonce: Nonce(0),
@@ -748,7 +753,7 @@ impl AccountWithMetadataForTests {
                     liquidity_pool_supply: BalanceForTests::vault_a_reserve_high(),
                     reserve_a: BalanceForTests::vault_a_reserve_high(),
                     reserve_b: BalanceForTests::vault_b_reserve_low(),
-                    fees: 0u128,
+                    fees: BalanceForTests::fee_tier(),
                     active: true,
                 }),
                 nonce: Nonce(0),
@@ -772,7 +777,7 @@ impl AccountWithMetadataForTests {
                     liquidity_pool_supply: BalanceForTests::lp_supply_init(),
                     reserve_a: BalanceForTests::vault_a_swap_test_1(),
                     reserve_b: BalanceForTests::vault_b_swap_test_1(),
-                    fees: 0u128,
+                    fees: BalanceForTests::fee_tier(),
                     active: true,
                 }),
                 nonce: Nonce(0),
@@ -796,7 +801,7 @@ impl AccountWithMetadataForTests {
                     liquidity_pool_supply: BalanceForTests::lp_supply_init(),
                     reserve_a: BalanceForTests::vault_a_swap_test_2(),
                     reserve_b: BalanceForTests::vault_b_swap_test_2(),
-                    fees: 0u128,
+                    fees: BalanceForTests::fee_tier(),
                     active: true,
                 }),
                 nonce: Nonce(0),
@@ -820,7 +825,7 @@ impl AccountWithMetadataForTests {
                     liquidity_pool_supply: BalanceForTests::vault_a_reserve_low(),
                     reserve_a: BalanceForTests::vault_a_reserve_init(),
                     reserve_b: BalanceForTests::vault_b_reserve_init(),
-                    fees: 0u128,
+                    fees: BalanceForTests::fee_tier(),
                     active: true,
                 }),
                 nonce: Nonce(0),
@@ -844,7 +849,7 @@ impl AccountWithMetadataForTests {
                     liquidity_pool_supply: 989,
                     reserve_a: BalanceForTests::vault_a_add_successful(),
                     reserve_b: BalanceForTests::vault_b_add_successful(),
-                    fees: 0u128,
+                    fees: BalanceForTests::fee_tier(),
                     active: true,
                 }),
                 nonce: Nonce(0),
@@ -868,7 +873,7 @@ impl AccountWithMetadataForTests {
                     liquidity_pool_supply: 607,
                     reserve_a: BalanceForTests::vault_a_remove_successful(),
                     reserve_b: BalanceForTests::vault_b_remove_successful(),
-                    fees: 0u128,
+                    fees: BalanceForTests::fee_tier(),
                     active: true,
                 }),
                 nonce: Nonce(0),
@@ -892,7 +897,7 @@ impl AccountWithMetadataForTests {
                     liquidity_pool_supply: BalanceForTests::lp_supply_init(),
                     reserve_a: BalanceForTests::vault_a_reserve_init(),
                     reserve_b: BalanceForTests::vault_b_reserve_init(),
-                    fees: 0u128,
+                    fees: BalanceForTests::fee_tier(),
                     active: false,
                 }),
                 nonce: Nonce(0),
@@ -916,7 +921,7 @@ impl AccountWithMetadataForTests {
                     liquidity_pool_supply: BalanceForTests::lp_supply_init(),
                     reserve_a: BalanceForTests::vault_a_reserve_init(),
                     reserve_b: BalanceForTests::vault_b_reserve_init(),
-                    fees: 0u128,
+                    fees: BalanceForTests::fee_tier(),
                     active: false,
                 }),
                 nonce: Nonce(0),
@@ -972,7 +977,7 @@ impl AccountWithMetadataForTests {
                     liquidity_pool_supply: BalanceForTests::lp_supply_init(),
                     reserve_a: BalanceForTests::vault_a_reserve_init(),
                     reserve_b: BalanceForTests::vault_b_reserve_init(),
-                    fees: 0u128,
+                    fees: BalanceForTests::fee_tier(),
                     active: true,
                 }),
                 nonce: Nonce(0),
@@ -1419,6 +1424,7 @@ fn test_call_new_definition_with_zero_balance_1() {
         AccountWithMetadataForTests::user_holding_lp_uninit(),
         NonZero::new(0).expect("Balances must be nonzero"),
         NonZero::new(BalanceForTests::vault_b_reserve_init()).unwrap(),
+        BalanceForTests::fee_tier(),
         AMM_PROGRAM_ID,
     );
 }
@@ -1436,6 +1442,7 @@ fn test_call_new_definition_with_zero_balance_2() {
         AccountWithMetadataForTests::user_holding_lp_uninit(),
         NonZero::new(BalanceForTests::vault_a_reserve_init()).unwrap(),
         NonZero::new(0).expect("Balances must be nonzero"),
+        BalanceForTests::fee_tier(),
         AMM_PROGRAM_ID,
     );
 }
@@ -1453,6 +1460,7 @@ fn test_call_new_definition_same_token_definition() {
         AccountWithMetadataForTests::user_holding_lp_uninit(),
         NonZero::new(BalanceForTests::vault_a_reserve_init()).unwrap(),
         NonZero::new(BalanceForTests::vault_b_reserve_init()).unwrap(),
+        BalanceForTests::fee_tier(),
         AMM_PROGRAM_ID,
     );
 }
@@ -1470,6 +1478,7 @@ fn test_call_new_definition_wrong_liquidity_id() {
         AccountWithMetadataForTests::user_holding_lp_uninit(),
         NonZero::new(BalanceForTests::vault_a_reserve_init()).unwrap(),
         NonZero::new(BalanceForTests::vault_b_reserve_init()).unwrap(),
+        BalanceForTests::fee_tier(),
         AMM_PROGRAM_ID,
     );
 }
@@ -1487,6 +1496,7 @@ fn test_call_new_definition_wrong_pool_id() {
         AccountWithMetadataForTests::user_holding_lp_uninit(),
         NonZero::new(BalanceForTests::vault_a_reserve_init()).unwrap(),
         NonZero::new(BalanceForTests::vault_b_reserve_init()).unwrap(),
+        BalanceForTests::fee_tier(),
         AMM_PROGRAM_ID,
     );
 }
@@ -1504,6 +1514,7 @@ fn test_call_new_definition_wrong_vault_id_1() {
         AccountWithMetadataForTests::user_holding_lp_uninit(),
         NonZero::new(BalanceForTests::vault_a_reserve_init()).unwrap(),
         NonZero::new(BalanceForTests::vault_b_reserve_init()).unwrap(),
+        BalanceForTests::fee_tier(),
         AMM_PROGRAM_ID,
     );
 }
@@ -1521,6 +1532,7 @@ fn test_call_new_definition_wrong_vault_id_2() {
         AccountWithMetadataForTests::user_holding_lp_uninit(),
         NonZero::new(BalanceForTests::vault_a_reserve_init()).unwrap(),
         NonZero::new(BalanceForTests::vault_b_reserve_init()).unwrap(),
+        BalanceForTests::fee_tier(),
         AMM_PROGRAM_ID,
     );
 }
@@ -1538,6 +1550,7 @@ fn test_call_new_definition_cannot_initialize_active_pool() {
         AccountWithMetadataForTests::user_holding_lp_uninit(),
         NonZero::new(BalanceForTests::vault_a_reserve_init()).unwrap(),
         NonZero::new(BalanceForTests::vault_b_reserve_init()).unwrap(),
+        BalanceForTests::fee_tier(),
         AMM_PROGRAM_ID,
     );
 }
@@ -1555,6 +1568,7 @@ fn test_call_new_definition_chained_call_successful() {
         AccountWithMetadataForTests::user_holding_lp_uninit(),
         NonZero::new(BalanceForTests::vault_a_reserve_init()).unwrap(),
         NonZero::new(BalanceForTests::vault_b_reserve_init()).unwrap(),
+        BalanceForTests::fee_tier(),
         AMM_PROGRAM_ID,
     );
 
@@ -1755,6 +1769,7 @@ fn test_new_definition_lp_asymmetric_amounts() {
         AccountWithMetadataForTests::user_holding_lp_uninit(),
         NonZero::new(BalanceForTests::vault_a_reserve_init()).unwrap(),
         NonZero::new(BalanceForTests::vault_b_reserve_init()).unwrap(),
+        BalanceForTests::fee_tier(),
         AMM_PROGRAM_ID,
     );
 
@@ -1788,6 +1803,7 @@ fn test_new_definition_lp_symmetric_amounts() {
         AccountWithMetadataForTests::user_holding_lp_uninit(),
         NonZero::new(token_a_amount).unwrap(),
         NonZero::new(token_b_amount).unwrap(),
+        BalanceForTests::fee_tier(),
         AMM_PROGRAM_ID,
     );
 
@@ -1811,4 +1827,50 @@ fn test_new_definition_lp_symmetric_amounts() {
     )]);
 
     assert_eq!(chained_call_lp, expected_lp_call);
+}
+
+#[test]
+fn test_new_definition_supports_all_fee_tiers() {
+    for fees in [
+        FEE_TIER_BPS_1,
+        FEE_TIER_BPS_5,
+        FEE_TIER_BPS_30,
+        FEE_TIER_BPS_100,
+    ] {
+        let (post_states, _) = new_definition(
+            AccountWithMetadataForTests::pool_definition_inactive(),
+            AccountWithMetadataForTests::vault_a_init(),
+            AccountWithMetadataForTests::vault_b_init(),
+            AccountWithMetadataForTests::pool_lp_init(),
+            AccountWithMetadataForTests::user_holding_a(),
+            AccountWithMetadataForTests::user_holding_b(),
+            AccountWithMetadataForTests::user_holding_lp_uninit(),
+            NonZero::new(BalanceForTests::vault_a_reserve_init()).unwrap(),
+            NonZero::new(BalanceForTests::vault_b_reserve_init()).unwrap(),
+            fees,
+            AMM_PROGRAM_ID,
+        );
+
+        let pool_post = post_states[0].clone();
+        let pool_def = PoolDefinition::try_from(&pool_post.account().data).unwrap();
+        assert_eq!(pool_def.fees, fees);
+    }
+}
+
+#[should_panic(expected = "Fee tier must be one of 1, 5, 30, or 100 basis points")]
+#[test]
+fn test_new_definition_rejects_unsupported_fee_tier() {
+    let _ = new_definition(
+        AccountWithMetadataForTests::pool_definition_inactive(),
+        AccountWithMetadataForTests::vault_a_init(),
+        AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::pool_lp_init(),
+        AccountWithMetadataForTests::user_holding_a(),
+        AccountWithMetadataForTests::user_holding_b(),
+        AccountWithMetadataForTests::user_holding_lp_uninit(),
+        NonZero::new(BalanceForTests::vault_a_reserve_init()).unwrap(),
+        NonZero::new(BalanceForTests::vault_b_reserve_init()).unwrap(),
+        2,
+        AMM_PROGRAM_ID,
+    );
 }

--- a/integration_tests/tests/amm.rs
+++ b/integration_tests/tests/amm.rs
@@ -1,5 +1,6 @@
 use amm_core::{PoolDefinition, FEE_TIER_BPS_1, FEE_TIER_BPS_100, FEE_TIER_BPS_30, FEE_TIER_BPS_5};
 use nssa::{
+    error::NssaError,
     program_deployment_transaction::{self, ProgramDeploymentTransaction},
     public_transaction, PrivateKey, PublicKey, PublicTransaction, V03State,
 };
@@ -889,7 +890,7 @@ fn state_for_amm_tests_with_new_def() -> V03State {
     state
 }
 
-fn execute_new_definition(state: &mut V03State, fees: u128) {
+fn try_execute_new_definition(state: &mut V03State, fees: u128) -> Result<(), NssaError> {
     let instruction = amm_core::Instruction::NewDefinition {
         token_a_amount: Balances::vault_a_init(),
         token_b_amount: Balances::vault_b_init(),
@@ -917,7 +918,11 @@ fn execute_new_definition(state: &mut V03State, fees: u128) {
         public_transaction::WitnessSet::for_message(&message, &[&Keys::user_a(), &Keys::user_b()]);
 
     let tx = PublicTransaction::new(message, witness_set);
-    state.transition_from_public_transaction(&tx, 0).unwrap();
+    state.transition_from_public_transaction(&tx, 0)
+}
+
+fn execute_new_definition(state: &mut V03State, fees: u128) {
+    try_execute_new_definition(state, fees).unwrap();
 }
 
 #[test]
@@ -1124,6 +1129,51 @@ fn amm_new_definition_supports_all_fee_tiers() {
                 .expect("new definition should create a valid pool");
         assert_eq!(pool_definition.fees, fees);
     }
+}
+
+#[test]
+fn amm_new_definition_rejects_unsupported_fee_tier_transaction() {
+    let mut state = state_for_amm_tests_with_new_def();
+    state.force_insert_account(Ids::vault_a(), Accounts::vault_a_init_inactive());
+    state.force_insert_account(Ids::vault_b(), Accounts::vault_b_init_inactive());
+    state.force_insert_account(Ids::pool_definition(), Accounts::pool_definition_inactive());
+    state.force_insert_account(
+        Ids::token_lp_definition(),
+        Accounts::token_lp_definition_init_inactive(),
+    );
+    state.force_insert_account(Ids::user_lp(), Accounts::user_lp_holding_init_zero());
+
+    let result = try_execute_new_definition(&mut state, 2);
+
+    assert!(matches!(result, Err(NssaError::ProgramExecutionFailed(_))));
+    assert_eq!(
+        state.get_account_by_id(Ids::pool_definition()),
+        Accounts::pool_definition_inactive()
+    );
+    assert_eq!(
+        state.get_account_by_id(Ids::vault_a()),
+        Accounts::vault_a_init_inactive()
+    );
+    assert_eq!(
+        state.get_account_by_id(Ids::vault_b()),
+        Accounts::vault_b_init_inactive()
+    );
+    assert_eq!(
+        state.get_account_by_id(Ids::token_lp_definition()),
+        Accounts::token_lp_definition_init_inactive()
+    );
+    assert_eq!(
+        state.get_account_by_id(Ids::user_a()),
+        Accounts::user_a_holding()
+    );
+    assert_eq!(
+        state.get_account_by_id(Ids::user_b()),
+        Accounts::user_b_holding()
+    );
+    assert_eq!(
+        state.get_account_by_id(Ids::user_lp()),
+        Accounts::user_lp_holding_init_zero()
+    );
 }
 
 #[test]

--- a/integration_tests/tests/amm.rs
+++ b/integration_tests/tests/amm.rs
@@ -1,4 +1,4 @@
-use amm_core::PoolDefinition;
+use amm_core::{PoolDefinition, FEE_TIER_BPS_1, FEE_TIER_BPS_100, FEE_TIER_BPS_30, FEE_TIER_BPS_5};
 use nssa::{
     program_deployment_transaction::{self, ProgramDeploymentTransaction},
     public_transaction, PrivateKey, PublicKey, PublicTransaction, V03State,
@@ -84,6 +84,10 @@ impl Ids {
 }
 
 impl Balances {
+    fn fee_tier() -> u128 {
+        FEE_TIER_BPS_30
+    }
+
     fn user_a_init() -> u128 {
         10_000
     }
@@ -283,7 +287,7 @@ impl Accounts {
                 liquidity_pool_supply: Balances::pool_lp_supply_init(),
                 reserve_a: Balances::vault_a_init(),
                 reserve_b: Balances::vault_b_init(),
-                fees: 0_u128,
+                fees: Balances::fee_tier(),
                 active: true,
             }),
             nonce: Nonce(0),
@@ -380,7 +384,7 @@ impl Accounts {
                 liquidity_pool_supply: Balances::pool_lp_supply_init(),
                 reserve_a: Balances::vault_a_swap_1(),
                 reserve_b: Balances::vault_b_swap_1(),
-                fees: 0_u128,
+                fees: Balances::fee_tier(),
                 active: true,
             }),
             nonce: Nonce(0),
@@ -448,7 +452,7 @@ impl Accounts {
                 liquidity_pool_supply: Balances::pool_lp_supply_init(),
                 reserve_a: Balances::vault_a_swap_2(),
                 reserve_b: Balances::vault_b_swap_2(),
-                fees: 0_u128,
+                fees: Balances::fee_tier(),
                 active: true,
             }),
             nonce: Nonce(0),
@@ -516,7 +520,7 @@ impl Accounts {
                 liquidity_pool_supply: Balances::token_lp_supply_add(),
                 reserve_a: Balances::vault_a_add(),
                 reserve_b: Balances::vault_b_add(),
-                fees: 0_u128,
+                fees: Balances::fee_tier(),
                 active: true,
             }),
             nonce: Nonce(0),
@@ -609,7 +613,7 @@ impl Accounts {
                 liquidity_pool_supply: Balances::token_lp_supply_remove(),
                 reserve_a: Balances::vault_a_remove(),
                 reserve_b: Balances::vault_b_remove(),
-                fees: 0_u128,
+                fees: Balances::fee_tier(),
                 active: true,
             }),
             nonce: Nonce(0),
@@ -739,7 +743,7 @@ impl Accounts {
                 liquidity_pool_supply: 0,
                 reserve_a: 0,
                 reserve_b: 0,
-                fees: 0_u128,
+                fees: Balances::fee_tier(),
                 active: false,
             }),
             nonce: Nonce(0),
@@ -808,7 +812,7 @@ impl Accounts {
                 liquidity_pool_supply: Balances::lp_supply_init(),
                 reserve_a: Balances::vault_a_init(),
                 reserve_b: Balances::vault_b_init(),
-                fees: 0_u128,
+                fees: Balances::fee_tier(),
                 active: true,
             }),
             nonce: Nonce(0),
@@ -885,6 +889,37 @@ fn state_for_amm_tests_with_new_def() -> V03State {
     state
 }
 
+fn execute_new_definition(state: &mut V03State, fees: u128) {
+    let instruction = amm_core::Instruction::NewDefinition {
+        token_a_amount: Balances::vault_a_init(),
+        token_b_amount: Balances::vault_b_init(),
+        fees,
+        amm_program_id: Ids::amm_program(),
+    };
+
+    let message = public_transaction::Message::try_new(
+        Ids::amm_program(),
+        vec![
+            Ids::pool_definition(),
+            Ids::vault_a(),
+            Ids::vault_b(),
+            Ids::token_lp_definition(),
+            Ids::user_a(),
+            Ids::user_b(),
+            Ids::user_lp(),
+        ],
+        vec![Nonce(0), Nonce(0)],
+        instruction,
+    )
+    .unwrap();
+
+    let witness_set =
+        public_transaction::WitnessSet::for_message(&message, &[&Keys::user_a(), &Keys::user_b()]);
+
+    let tx = PublicTransaction::new(message, witness_set);
+    state.transition_from_public_transaction(&tx, 0).unwrap();
+}
+
 #[test]
 fn amm_remove_liquidity() {
     let mut state = state_for_amm_tests();
@@ -957,33 +992,7 @@ fn amm_new_definition_inactive_initialized_pool_and_uninit_user_lp() {
         Accounts::token_lp_definition_init_inactive(),
     );
 
-    let instruction = amm_core::Instruction::NewDefinition {
-        token_a_amount: Balances::vault_a_init(),
-        token_b_amount: Balances::vault_b_init(),
-        amm_program_id: Ids::amm_program(),
-    };
-
-    let message = public_transaction::Message::try_new(
-        Ids::amm_program(),
-        vec![
-            Ids::pool_definition(),
-            Ids::vault_a(),
-            Ids::vault_b(),
-            Ids::token_lp_definition(),
-            Ids::user_a(),
-            Ids::user_b(),
-            Ids::user_lp(),
-        ],
-        vec![Nonce(0), Nonce(0)],
-        instruction,
-    )
-    .unwrap();
-
-    let witness_set =
-        public_transaction::WitnessSet::for_message(&message, &[&Keys::user_a(), &Keys::user_b()]);
-
-    let tx = PublicTransaction::new(message, witness_set);
-    state.transition_from_public_transaction(&tx, 0).unwrap();
+    execute_new_definition(&mut state, Balances::fee_tier());
 
     assert_eq!(
         state.get_account_by_id(Ids::pool_definition()),
@@ -1027,33 +1036,7 @@ fn amm_new_definition_inactive_initialized_pool_init_user_lp() {
     );
     state.force_insert_account(Ids::user_lp(), Accounts::user_lp_holding_init_zero());
 
-    let instruction = amm_core::Instruction::NewDefinition {
-        token_a_amount: Balances::vault_a_init(),
-        token_b_amount: Balances::vault_b_init(),
-        amm_program_id: Ids::amm_program(),
-    };
-
-    let message = public_transaction::Message::try_new(
-        Ids::amm_program(),
-        vec![
-            Ids::pool_definition(),
-            Ids::vault_a(),
-            Ids::vault_b(),
-            Ids::token_lp_definition(),
-            Ids::user_a(),
-            Ids::user_b(),
-            Ids::user_lp(),
-        ],
-        vec![Nonce(0), Nonce(0)],
-        instruction,
-    )
-    .unwrap();
-
-    let witness_set =
-        public_transaction::WitnessSet::for_message(&message, &[&Keys::user_a(), &Keys::user_b()]);
-
-    let tx = PublicTransaction::new(message, witness_set);
-    state.transition_from_public_transaction(&tx, 0).unwrap();
+    execute_new_definition(&mut state, Balances::fee_tier());
 
     assert_eq!(
         state.get_account_by_id(Ids::pool_definition()),
@@ -1090,34 +1073,7 @@ fn amm_new_definition_uninitialized_pool() {
     let mut state = state_for_amm_tests_with_new_def();
     state.force_insert_account(Ids::vault_a(), Accounts::vault_a_init_inactive());
     state.force_insert_account(Ids::vault_b(), Accounts::vault_b_init_inactive());
-
-    let instruction = amm_core::Instruction::NewDefinition {
-        token_a_amount: Balances::vault_a_init(),
-        token_b_amount: Balances::vault_b_init(),
-        amm_program_id: Ids::amm_program(),
-    };
-
-    let message = public_transaction::Message::try_new(
-        Ids::amm_program(),
-        vec![
-            Ids::pool_definition(),
-            Ids::vault_a(),
-            Ids::vault_b(),
-            Ids::token_lp_definition(),
-            Ids::user_a(),
-            Ids::user_b(),
-            Ids::user_lp(),
-        ],
-        vec![Nonce(0), Nonce(0)],
-        instruction,
-    )
-    .unwrap();
-
-    let witness_set =
-        public_transaction::WitnessSet::for_message(&message, &[&Keys::user_a(), &Keys::user_b()]);
-
-    let tx = PublicTransaction::new(message, witness_set);
-    state.transition_from_public_transaction(&tx, 0).unwrap();
+    execute_new_definition(&mut state, Balances::fee_tier());
 
     assert_eq!(
         state.get_account_by_id(Ids::pool_definition()),
@@ -1147,6 +1103,27 @@ fn amm_new_definition_uninitialized_pool() {
         state.get_account_by_id(Ids::user_lp()),
         Accounts::user_lp_holding_new_init()
     );
+}
+
+#[test]
+fn amm_new_definition_supports_all_fee_tiers() {
+    for fees in [
+        FEE_TIER_BPS_1,
+        FEE_TIER_BPS_5,
+        FEE_TIER_BPS_30,
+        FEE_TIER_BPS_100,
+    ] {
+        let mut state = state_for_amm_tests_with_new_def();
+        state.force_insert_account(Ids::vault_a(), Accounts::vault_a_init_inactive());
+        state.force_insert_account(Ids::vault_b(), Accounts::vault_b_init_inactive());
+
+        execute_new_definition(&mut state, fees);
+
+        let pool_definition =
+            PoolDefinition::try_from(&state.get_account_by_id(Ids::pool_definition()).data)
+                .expect("new definition should create a valid pool");
+        assert_eq!(pool_definition.fees, fees);
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Purpose
Introduce configurable AMM fee tiers so each pool stores an explicit trading-fee setting at creation time, and reject unsupported fee tiers when creating or operating on a pool.
Closes #18

## What Changed
- Added a required `fees` argument to `NewDefinition`, the AMM guest entrypoint, and `amm/amm-idl.json`.
- Defined supported AMM fee tiers in basis points (`1`, `5`, `30`, `100`) and stored the selected tier in `PoolDefinition.fees`.
- Validated fee tiers during pool creation and rejected unsupported values before initialization.
- Made add-liquidity, remove-liquidity, and swap treat unsupported stored `fees` values as invalid pool state.
- Expanded unit coverage for all supported tiers, invalid-tier rejection in `new_definition`, and invalid stored-fee rejection in `swap`.
- Expanded integration coverage for invalid-tier `NewDefinition` transactions and confirmed the transaction fails without mutating accounts.

## Review Focus
- The public AMM instruction and IDL surface now requires `fees` for pool creation.
- Unsupported fee tiers are rejected both at pool-creation time and when later AMM operations read pool state.
- Invalid `NewDefinition` transactions leave pool, vault, LP definition, and user holdings unchanged.

## How To Test
1. `cargo +nightly fmt --all -- --check`
2. `taplo fmt --check .`
3. `RISC0_SKIP_BUILD=1 cargo +1.94.0 clippy --workspace --all-targets -- -D warnings`
4. `RISC0_DEV_MODE=1 cargo +1.94.0 test --workspace --exclude integration_tests`
5. `RISC0_DEV_MODE=1 cargo +1.94.0 test -p integration_tests`
