### PR TITLE
chore: update `spel` and `logos-execution-zone` dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,22 +378,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
-name = "bitcoin-io"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
-dependencies = [
- "bitcoin-io",
- "hex-conservative",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1285,15 +1269,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hex-conservative"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
-dependencies = [
- "arrayvec",
-]
-
-[[package]]
 name = "hex-literal"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1837,18 +1812,18 @@ checksum = "a5b0c77c1b780822bc749a33e39aeb2c07584ab93332303babeabb645298a76e"
 [[package]]
 name = "nssa"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git#085ca69e422c20125199e136b602641b76e95939"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=ffcbc15972adbf557939bf3e2852af276422631b#ffcbc15972adbf557939bf3e2852af276422631b"
 dependencies = [
  "anyhow",
  "borsh",
  "hex",
+ "k256",
  "log",
  "nssa_core",
  "rand 0.8.5",
  "risc0-binfmt",
  "risc0-build",
  "risc0-zkvm",
- "secp256k1",
  "serde",
  "serde_with",
  "sha2",
@@ -1858,7 +1833,7 @@ dependencies = [
 [[package]]
 name = "nssa_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git#085ca69e422c20125199e136b602641b76e95939"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=ffcbc15972adbf557939bf3e2852af276422631b#ffcbc15972adbf557939bf3e2852af276422631b"
 dependencies = [
  "base58",
  "borsh",
@@ -2810,26 +2785,6 @@ dependencies = [
  "serdect",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "secp256k1"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
-dependencies = [
- "bitcoin_hashes",
- "rand 0.9.2",
- "secp256k1-sys",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
-dependencies = [
- "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ exclude = [
 resolver = "2"
 
 [workspace.dependencies]
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", features = ["host"] }
-nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", features = ["test-utils"] }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b", features = ["host"] }
+nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b", features = ["test-utils"] }
 token_core = { path = "token/core" }
 token_program = { path = "token" }
 amm_core = { path = "amm/core" }
@@ -33,5 +33,3 @@ risc0-zkvm = { version = "=3.0.5" }
 serde_json = "1.0"
 tokio = { version = "1.28.2", features = ["net", "rt-multi-thread", "sync", "macros"] }
 
-[patch."https://github.com/logos-blockchain/lssa.git"]
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git" }

--- a/amm/Cargo.toml
+++ b/amm/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", features = ["host"] }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b", features = ["host"] }
 amm_core = { path = "core" }
 token_core = { path = "../token/core" }

--- a/amm/core/Cargo.toml
+++ b/amm/core/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", features = ["host"] }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b", features = ["host"] }
 borsh = { version = "1.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 risc0-zkvm = { version = "=3.0.5", default-features = false }

--- a/amm/methods/guest/Cargo.lock
+++ b/amm/methods/guest/Cargo.lock
@@ -1777,7 +1777,7 @@ checksum = "a5b0c77c1b780822bc749a33e39aeb2c07584ab93332303babeabb645298a76e"
 [[package]]
 name = "nssa_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git#085ca69e422c20125199e136b602641b76e95939"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=ffcbc15972adbf557939bf3e2852af276422631b#ffcbc15972adbf557939bf3e2852af276422631b"
 dependencies = [
  "base58",
  "borsh",
@@ -2897,7 +2897,7 @@ dependencies = [
 [[package]]
 name = "spel-framework"
 version = "0.1.0"
-source = "git+https://github.com/0x-r4bbit/spel.git?branch=fix%2Fnssa-v03-compat#743da71a5b27871bd9c7141c20fd4cbe5fe22464"
+source = "git+https://github.com/logos-co/spel.git?rev=57201f64b4542bb3f592bc9a0aa654c47aa908a6#57201f64b4542bb3f592bc9a0aa654c47aa908a6"
 dependencies = [
  "borsh",
  "nssa_core",
@@ -2908,7 +2908,7 @@ dependencies = [
 [[package]]
 name = "spel-framework-core"
 version = "0.1.0"
-source = "git+https://github.com/0x-r4bbit/spel.git?branch=fix%2Fnssa-v03-compat#743da71a5b27871bd9c7141c20fd4cbe5fe22464"
+source = "git+https://github.com/logos-co/spel.git?rev=57201f64b4542bb3f592bc9a0aa654c47aa908a6#57201f64b4542bb3f592bc9a0aa654c47aa908a6"
 dependencies = [
  "borsh",
  "nssa_core",
@@ -2921,7 +2921,7 @@ dependencies = [
 [[package]]
 name = "spel-framework-macros"
 version = "0.1.0"
-source = "git+https://github.com/0x-r4bbit/spel.git?branch=fix%2Fnssa-v03-compat#743da71a5b27871bd9c7141c20fd4cbe5fe22464"
+source = "git+https://github.com/logos-co/spel.git?rev=57201f64b4542bb3f592bc9a0aa654c47aa908a6#57201f64b4542bb3f592bc9a0aa654c47aa908a6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/amm/methods/guest/Cargo.toml
+++ b/amm/methods/guest/Cargo.toml
@@ -5,16 +5,13 @@ edition = "2021"
 
 [workspace]
 
-[patch."https://github.com/logos-blockchain/lssa.git"]
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git" }
-
 [[bin]]
 name = "amm"
 path = "src/bin/amm.rs"
 
 [dependencies]
-spel-framework = { git = "https://github.com/0x-r4bbit/spel.git", branch = "fix/nssa-v03-compat", package = "spel-framework" }
-nssa_core = { git = "https://github.com/logos-blockchain/lssa.git", rev = "767b5afd388c7981bcdf6f5b5c80159607e07e5b" }
+spel-framework = { git = "https://github.com/logos-co/spel.git", rev = "57201f64b4542bb3f592bc9a0aa654c47aa908a6", package = "spel-framework" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b" }
 risc0-zkvm = { version = "=3.0.5", default-features = false }
 amm_core = { path = "../../core" }
 amm_program = { path = "../..", package = "amm_program" }

--- a/ata/Cargo.toml
+++ b/ata/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", features = ["host"] }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b", features = ["host"] }
 ata_core = { path = "core" }
 token_core = { path = "../token/core" }

--- a/ata/core/Cargo.toml
+++ b/ata/core/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", features = ["host"] }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b", features = ["host"] }
 borsh = { version = "1.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 risc0-zkvm = { version = "=3.0.5", default-features = false }

--- a/ata/methods/guest/Cargo.lock
+++ b/ata/methods/guest/Cargo.lock
@@ -1777,7 +1777,7 @@ checksum = "a5b0c77c1b780822bc749a33e39aeb2c07584ab93332303babeabb645298a76e"
 [[package]]
 name = "nssa_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git#085ca69e422c20125199e136b602641b76e95939"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=ffcbc15972adbf557939bf3e2852af276422631b#ffcbc15972adbf557939bf3e2852af276422631b"
 dependencies = [
  "base58",
  "borsh",
@@ -2897,7 +2897,7 @@ dependencies = [
 [[package]]
 name = "spel-framework"
 version = "0.1.0"
-source = "git+https://github.com/0x-r4bbit/spel.git?branch=fix%2Fnssa-v03-compat#743da71a5b27871bd9c7141c20fd4cbe5fe22464"
+source = "git+https://github.com/logos-co/spel.git?rev=57201f64b4542bb3f592bc9a0aa654c47aa908a6#57201f64b4542bb3f592bc9a0aa654c47aa908a6"
 dependencies = [
  "borsh",
  "nssa_core",
@@ -2908,7 +2908,7 @@ dependencies = [
 [[package]]
 name = "spel-framework-core"
 version = "0.1.0"
-source = "git+https://github.com/0x-r4bbit/spel.git?branch=fix%2Fnssa-v03-compat#743da71a5b27871bd9c7141c20fd4cbe5fe22464"
+source = "git+https://github.com/logos-co/spel.git?rev=57201f64b4542bb3f592bc9a0aa654c47aa908a6#57201f64b4542bb3f592bc9a0aa654c47aa908a6"
 dependencies = [
  "borsh",
  "nssa_core",
@@ -2921,7 +2921,7 @@ dependencies = [
 [[package]]
 name = "spel-framework-macros"
 version = "0.1.0"
-source = "git+https://github.com/0x-r4bbit/spel.git?branch=fix%2Fnssa-v03-compat#743da71a5b27871bd9c7141c20fd4cbe5fe22464"
+source = "git+https://github.com/logos-co/spel.git?rev=57201f64b4542bb3f592bc9a0aa654c47aa908a6#57201f64b4542bb3f592bc9a0aa654c47aa908a6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/ata/methods/guest/Cargo.toml
+++ b/ata/methods/guest/Cargo.toml
@@ -5,16 +5,13 @@ edition = "2021"
 
 [workspace]
 
-[patch."https://github.com/logos-blockchain/lssa.git"]
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git" }
-
 [[bin]]
 name = "ata"
 path = "src/bin/ata.rs"
 
 [dependencies]
-spel-framework = { git = "https://github.com/0x-r4bbit/spel.git", branch = "fix/nssa-v03-compat", package = "spel-framework" }
-nssa_core = { git = "https://github.com/logos-blockchain/lssa.git", rev = "767b5afd388c7981bcdf6f5b5c80159607e07e5b" }
+spel-framework = { git = "https://github.com/logos-co/spel.git", rev = "57201f64b4542bb3f592bc9a0aa654c47aa908a6", package = "spel-framework" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b" }
 risc0-zkvm = { version = "=3.0.5", default-features = false }
 ata_core = { path = "../../core" }
 ata_program = { path = "../..", package = "ata_program" }

--- a/token/Cargo.toml
+++ b/token/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", features = ["host"] }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b", features = ["host"] }
 token_core = { path = "core" }

--- a/token/core/Cargo.toml
+++ b/token/core/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", features = ["host"] }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b", features = ["host"] }
 borsh = { version = "1.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/token/methods/guest/Cargo.lock
+++ b/token/methods/guest/Cargo.lock
@@ -1744,7 +1744,7 @@ checksum = "a5b0c77c1b780822bc749a33e39aeb2c07584ab93332303babeabb645298a76e"
 [[package]]
 name = "nssa_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git#085ca69e422c20125199e136b602641b76e95939"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=ffcbc15972adbf557939bf3e2852af276422631b#ffcbc15972adbf557939bf3e2852af276422631b"
 dependencies = [
  "base58",
  "borsh",
@@ -2864,7 +2864,7 @@ dependencies = [
 [[package]]
 name = "spel-framework"
 version = "0.1.0"
-source = "git+https://github.com/0x-r4bbit/spel.git?branch=fix%2Fnssa-v03-compat#743da71a5b27871bd9c7141c20fd4cbe5fe22464"
+source = "git+https://github.com/logos-co/spel.git?rev=57201f64b4542bb3f592bc9a0aa654c47aa908a6#57201f64b4542bb3f592bc9a0aa654c47aa908a6"
 dependencies = [
  "borsh",
  "nssa_core",
@@ -2875,7 +2875,7 @@ dependencies = [
 [[package]]
 name = "spel-framework-core"
 version = "0.1.0"
-source = "git+https://github.com/0x-r4bbit/spel.git?branch=fix%2Fnssa-v03-compat#743da71a5b27871bd9c7141c20fd4cbe5fe22464"
+source = "git+https://github.com/logos-co/spel.git?rev=57201f64b4542bb3f592bc9a0aa654c47aa908a6#57201f64b4542bb3f592bc9a0aa654c47aa908a6"
 dependencies = [
  "borsh",
  "nssa_core",
@@ -2888,7 +2888,7 @@ dependencies = [
 [[package]]
 name = "spel-framework-macros"
 version = "0.1.0"
-source = "git+https://github.com/0x-r4bbit/spel.git?branch=fix%2Fnssa-v03-compat#743da71a5b27871bd9c7141c20fd4cbe5fe22464"
+source = "git+https://github.com/logos-co/spel.git?rev=57201f64b4542bb3f592bc9a0aa654c47aa908a6#57201f64b4542bb3f592bc9a0aa654c47aa908a6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/token/methods/guest/Cargo.toml
+++ b/token/methods/guest/Cargo.toml
@@ -5,16 +5,13 @@ edition = "2021"
 
 [workspace]
 
-[patch."https://github.com/logos-blockchain/lssa.git"]
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git" }
-
 [[bin]]
 name = "token"
 path = "src/bin/token.rs"
 
 [dependencies]
-spel-framework = { git = "https://github.com/0x-r4bbit/spel.git", branch = "fix/nssa-v03-compat", package = "spel-framework" }
-nssa_core = { git = "https://github.com/logos-blockchain/lssa.git", rev = "767b5afd388c7981bcdf6f5b5c80159607e07e5b" }
+spel-framework = { git = "https://github.com/logos-co/spel.git", rev = "57201f64b4542bb3f592bc9a0aa654c47aa908a6", package = "spel-framework" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b" }
 risc0-zkvm = { version = "=3.0.5", default-features = false }
 token_core = { path = "../../core" }
 token_program = { path = "../..", package = "token_program" }


### PR DESCRIPTION
This removes the need to depend on a custom version, since the necessary changes have landed in `spel` upstream.