### PR TITLE
Add RecoverSurplus Instruction For AMM Pools

### DIFF
--- a/amm/amm-idl.json
+++ b/amm/amm-idl.json
@@ -233,6 +233,49 @@
           "type": "account_id"
         }
       ]
+    },
+    {
+      "name": "recover_surplus",
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": false,
+          "signer": false,
+          "init": false
+        },
+        {
+          "name": "vault_a",
+          "writable": false,
+          "signer": false,
+          "init": false
+        },
+        {
+          "name": "vault_b",
+          "writable": false,
+          "signer": false,
+          "init": false
+        },
+        {
+          "name": "to_holding_a",
+          "writable": false,
+          "signer": false,
+          "init": false
+        },
+        {
+          "name": "to_holding_b",
+          "writable": false,
+          "signer": false,
+          "init": false
+        }
+      ],
+      "args": [
+        {
+          "name": "mode",
+          "type": {
+            "defined": "RecoverSurplusMode"
+          }
+        }
+      ]
     }
   ],
   "instruction_type": "amm_core::Instruction"

--- a/amm/core/src/lib.rs
+++ b/amm/core/src/lib.rs
@@ -73,6 +73,21 @@ pub enum Instruction {
         min_amount_out: u128,
         token_definition_id_in: AccountId,
     },
+
+    /// Recover vault surplus balances that are not reserve-backed.
+    ///
+    /// Required accounts:
+    /// - AMM Pool (initialized)
+    /// - Vault Holding Account for Token A (initialized)
+    /// - Vault Holding Account for Token B (initialized)
+    /// - Recipient Holding Account for Token A (initialized)
+    /// - Recipient Holding Account for Token B (initialized)
+    RecoverSurplus { mode: RecoverSurplusMode },
+}
+
+#[derive(Clone, Copy, Serialize, Deserialize)]
+pub enum RecoverSurplusMode {
+    InactiveOrZeroSupplyOnly,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]

--- a/amm/core/src/lib.rs
+++ b/amm/core/src/lib.rs
@@ -80,8 +80,8 @@ pub enum Instruction {
     /// reserves unchanged.
     ///
     /// Recovery availability is gated by `mode`. The initial
-    /// [`RecoverSurplusMode::InactiveOrZeroSupplyOnly`] mode only permits recovery for pools that
-    /// are inactive or have zero LP supply.
+    /// [`RecoverSurplusMode::InactiveOrZeroSupplyOnly`] mode currently permits recovery only for
+    /// pools that are inactive.
     ///
     /// Required accounts:
     /// - AMM Pool (initialized)
@@ -94,7 +94,9 @@ pub enum Instruction {
 
 #[derive(Clone, Copy, Serialize, Deserialize)]
 pub enum RecoverSurplusMode {
-    /// Permit recovery only for pools that are inactive or whose LP supply is zero.
+    /// Currently permit recovery only for pools that are inactive.
+    ///
+    /// The broader name is retained for compatibility with the existing public instruction shape.
     InactiveOrZeroSupplyOnly,
 }
 

--- a/amm/core/src/lib.rs
+++ b/amm/core/src/lib.rs
@@ -76,6 +76,13 @@ pub enum Instruction {
 
     /// Recover vault surplus balances that are not reserve-backed.
     ///
+    /// This transfers only balances above `reserve_a` and `reserve_b`, leaving the stored pool
+    /// reserves unchanged.
+    ///
+    /// Recovery availability is gated by `mode`. The initial
+    /// [`RecoverSurplusMode::InactiveOrZeroSupplyOnly`] mode only permits recovery for pools that
+    /// are inactive or have zero LP supply.
+    ///
     /// Required accounts:
     /// - AMM Pool (initialized)
     /// - Vault Holding Account for Token A (initialized)
@@ -87,6 +94,7 @@ pub enum Instruction {
 
 #[derive(Clone, Copy, Serialize, Deserialize)]
 pub enum RecoverSurplusMode {
+    /// Permit recovery only for pools that are inactive or whose LP supply is zero.
     InactiveOrZeroSupplyOnly,
 }
 

--- a/amm/methods/guest/src/bin/amm.rs
+++ b/amm/methods/guest/src/bin/amm.rs
@@ -129,6 +129,9 @@ mod amm {
     }
 
     /// Recover vault surplus balances that are not reserve-backed.
+    ///
+    /// This transfers only balances above the tracked reserves. The current recovery mode permits
+    /// this only for pools that are inactive or have zero LP supply.
     #[instruction]
     pub fn recover_surplus(
         pool: AccountWithMetadata,

--- a/amm/methods/guest/src/bin/amm.rs
+++ b/amm/methods/guest/src/bin/amm.rs
@@ -127,4 +127,25 @@ mod amm {
         );
         Ok(SpelOutput::with_chained_calls(post_states, chained_calls))
     }
+
+    /// Recover vault surplus balances that are not reserve-backed.
+    #[instruction]
+    pub fn recover_surplus(
+        pool: AccountWithMetadata,
+        vault_a: AccountWithMetadata,
+        vault_b: AccountWithMetadata,
+        to_holding_a: AccountWithMetadata,
+        to_holding_b: AccountWithMetadata,
+        mode: amm_core::RecoverSurplusMode,
+    ) -> SpelResult {
+        let (post_states, chained_calls) = amm_program::recover::recover_surplus(
+            pool,
+            vault_a,
+            vault_b,
+            to_holding_a,
+            to_holding_b,
+            mode,
+        );
+        Ok(SpelOutput::with_chained_calls(post_states, chained_calls))
+    }
 }

--- a/amm/methods/guest/src/bin/amm.rs
+++ b/amm/methods/guest/src/bin/amm.rs
@@ -131,7 +131,7 @@ mod amm {
     /// Recover vault surplus balances that are not reserve-backed.
     ///
     /// This transfers only balances above the tracked reserves. The current recovery mode permits
-    /// this only for pools that are inactive or have zero LP supply.
+    /// this only for pools that are inactive.
     #[instruction]
     pub fn recover_surplus(
         pool: AccountWithMetadata,

--- a/amm/src/lib.rs
+++ b/amm/src/lib.rs
@@ -4,7 +4,10 @@ pub use amm_core as core;
 
 pub mod add;
 pub mod new_definition;
+pub mod recover;
 pub mod remove;
 pub mod swap;
+
+mod vault_utils;
 
 mod tests;

--- a/amm/src/recover.rs
+++ b/amm/src/recover.rs
@@ -69,8 +69,8 @@ pub fn recover_surplus(
     match mode {
         RecoverSurplusMode::InactiveOrZeroSupplyOnly => {
             assert!(
-                !pool_def_data.active || pool_def_data.liquidity_pool_supply == 0,
-                "Recover surplus is only allowed for inactive or zero-supply pools"
+                !pool_def_data.active,
+                "Recover surplus is only allowed for inactive pools"
             );
         }
     }

--- a/amm/src/recover.rs
+++ b/amm/src/recover.rs
@@ -1,0 +1,139 @@
+use amm_core::{compute_vault_pda_seed, PoolDefinition, RecoverSurplusMode};
+use nssa_core::{
+    account::AccountWithMetadata,
+    program::{AccountPostState, ChainedCall},
+};
+
+use crate::vault_utils::read_fungible_holding;
+
+pub fn recover_surplus(
+    pool: AccountWithMetadata,
+    vault_a: AccountWithMetadata,
+    vault_b: AccountWithMetadata,
+    to_holding_a: AccountWithMetadata,
+    to_holding_b: AccountWithMetadata,
+    mode: RecoverSurplusMode,
+) -> (Vec<AccountPostState>, Vec<ChainedCall>) {
+    let pool_def_data = PoolDefinition::try_from(&pool.account.data)
+        .expect("Recover surplus: AMM Program expects a valid Pool Definition Account");
+
+    assert_eq!(
+        vault_a.account_id, pool_def_data.vault_a_id,
+        "Vault A was not provided"
+    );
+    assert_eq!(
+        vault_b.account_id, pool_def_data.vault_b_id,
+        "Vault B was not provided"
+    );
+
+    let token_program_id = vault_a.account.program_owner;
+    assert_eq!(
+        vault_b.account.program_owner, token_program_id,
+        "Vaults must use the same Token Program"
+    );
+    assert_eq!(
+        to_holding_a.account.program_owner, token_program_id,
+        "Recipient A holding must use the same Token Program"
+    );
+    assert_eq!(
+        to_holding_b.account.program_owner, token_program_id,
+        "Recipient B holding must use the same Token Program"
+    );
+
+    let (vault_a_definition_id, vault_a_balance) =
+        read_fungible_holding(&vault_a, "Recover surplus Vault A");
+    let (vault_b_definition_id, vault_b_balance) =
+        read_fungible_holding(&vault_b, "Recover surplus Vault B");
+    assert_eq!(
+        vault_a_definition_id, pool_def_data.definition_token_a_id,
+        "Vault A token definition mismatch"
+    );
+    assert_eq!(
+        vault_b_definition_id, pool_def_data.definition_token_b_id,
+        "Vault B token definition mismatch"
+    );
+
+    let (recipient_a_definition_id, _) =
+        read_fungible_holding(&to_holding_a, "Recover surplus Recipient A");
+    let (recipient_b_definition_id, _) =
+        read_fungible_holding(&to_holding_b, "Recover surplus Recipient B");
+    assert_eq!(
+        recipient_a_definition_id, pool_def_data.definition_token_a_id,
+        "Recipient holding A token definition mismatch"
+    );
+    assert_eq!(
+        recipient_b_definition_id, pool_def_data.definition_token_b_id,
+        "Recipient holding B token definition mismatch"
+    );
+
+    match mode {
+        RecoverSurplusMode::InactiveOrZeroSupplyOnly => {
+            assert!(
+                !pool_def_data.active || pool_def_data.liquidity_pool_supply == 0,
+                "Recover surplus is only allowed for inactive or zero-supply pools"
+            );
+        }
+    }
+
+    assert!(
+        vault_a_balance >= pool_def_data.reserve_a,
+        "Recover surplus: vault A balance is less than its reserve"
+    );
+    assert!(
+        vault_b_balance >= pool_def_data.reserve_b,
+        "Recover surplus: vault B balance is less than its reserve"
+    );
+    let surplus_a = vault_a_balance - pool_def_data.reserve_a;
+    let surplus_b = vault_b_balance - pool_def_data.reserve_b;
+
+    let mut chained_calls = Vec::new();
+
+    if surplus_a > 0 {
+        let mut vault_a_auth = vault_a.clone();
+        vault_a_auth.is_authorized = true;
+        chained_calls.push(
+            ChainedCall::new(
+                token_program_id,
+                vec![vault_a_auth, to_holding_a.clone()],
+                &token_core::Instruction::Transfer {
+                    amount_to_transfer: surplus_a,
+                },
+            )
+            .with_pda_seeds(vec![compute_vault_pda_seed(
+                pool.account_id,
+                pool_def_data.definition_token_a_id,
+            )]),
+        );
+    }
+
+    if surplus_b > 0 {
+        let mut vault_b_auth = vault_b.clone();
+        vault_b_auth.is_authorized = true;
+        chained_calls.push(
+            ChainedCall::new(
+                token_program_id,
+                vec![vault_b_auth, to_holding_b.clone()],
+                &token_core::Instruction::Transfer {
+                    amount_to_transfer: surplus_b,
+                },
+            )
+            .with_pda_seeds(vec![compute_vault_pda_seed(
+                pool.account_id,
+                pool_def_data.definition_token_b_id,
+            )]),
+        );
+    }
+
+    // Surplus recovery only transfers balances above the tracked reserves, so the pool reserves
+    // remain unchanged and no follow-up sync is required.
+    (
+        vec![
+            AccountPostState::new(pool.account.clone()),
+            AccountPostState::new(vault_a.account.clone()),
+            AccountPostState::new(vault_b.account.clone()),
+            AccountPostState::new(to_holding_a.account.clone()),
+            AccountPostState::new(to_holding_b.account.clone()),
+        ],
+        chained_calls,
+    )
+}

--- a/amm/src/tests.rs
+++ b/amm/src/tests.rs
@@ -903,6 +903,30 @@ impl AccountWithMetadataForTests {
         }
     }
 
+    fn pool_definition_active_zero_supply() -> AccountWithMetadata {
+        AccountWithMetadata {
+            account: Account {
+                program_owner: ProgramId::default(),
+                balance: 0u128,
+                data: Data::from(&PoolDefinition {
+                    definition_token_a_id: IdForTests::token_a_definition_id(),
+                    definition_token_b_id: IdForTests::token_b_definition_id(),
+                    vault_a_id: IdForTests::vault_a_id(),
+                    vault_b_id: IdForTests::vault_b_id(),
+                    liquidity_pool_id: IdForTests::token_lp_definition_id(),
+                    liquidity_pool_supply: 0,
+                    reserve_a: BalanceForTests::vault_a_reserve_init(),
+                    reserve_b: BalanceForTests::vault_b_reserve_init(),
+                    fees: 0u128,
+                    active: true,
+                }),
+                nonce: Nonce(0),
+            },
+            is_authorized: true,
+            account_id: IdForTests::pool_definition_id(),
+        }
+    }
+
     fn pool_definition_with_wrong_id() -> AccountWithMetadata {
         AccountWithMetadata {
             account: Account {
@@ -1859,7 +1883,7 @@ fn test_recover_surplus_inactive_pool_transfers_only_surplus() {
     assert_eq!(chained_calls[0], expected_call);
 }
 
-#[should_panic(expected = "Recover surplus is only allowed for inactive or zero-supply pools")]
+#[should_panic(expected = "Recover surplus is only allowed for inactive pools")]
 #[test]
 fn test_recover_surplus_forbidden_for_active_pool() {
     let mut donated_vault_a = AccountWithMetadataForTests::vault_a_init();
@@ -1870,6 +1894,25 @@ fn test_recover_surplus_forbidden_for_active_pool() {
 
     let _ = recover_surplus(
         AccountWithMetadataForTests::pool_definition_init(),
+        donated_vault_a,
+        AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::user_holding_a(),
+        AccountWithMetadataForTests::user_holding_b(),
+        RecoverSurplusMode::InactiveOrZeroSupplyOnly,
+    );
+}
+
+#[should_panic(expected = "Recover surplus is only allowed for inactive pools")]
+#[test]
+fn test_recover_surplus_forbidden_for_active_zero_supply_pool() {
+    let mut donated_vault_a = AccountWithMetadataForTests::vault_a_init();
+    donated_vault_a.account.data = Data::from(&TokenHolding::Fungible {
+        definition_id: IdForTests::token_a_definition_id(),
+        balance: BalanceForTests::vault_a_reserve_init() + 1,
+    });
+
+    let _ = recover_surplus(
+        AccountWithMetadataForTests::pool_definition_active_zero_supply(),
         donated_vault_a,
         AccountWithMetadataForTests::vault_b_init(),
         AccountWithMetadataForTests::user_holding_a(),

--- a/amm/src/tests.rs
+++ b/amm/src/tests.rs
@@ -4,7 +4,7 @@ use std::num::NonZero;
 
 use amm_core::{
     compute_liquidity_token_pda, compute_liquidity_token_pda_seed, compute_pool_pda,
-    compute_vault_pda, compute_vault_pda_seed, PoolDefinition,
+    compute_vault_pda, compute_vault_pda_seed, PoolDefinition, RecoverSurplusMode,
 };
 use nssa_core::{
     account::{Account, AccountId, AccountWithMetadata, Data, Nonce},
@@ -13,7 +13,8 @@ use nssa_core::{
 use token_core::{TokenDefinition, TokenHolding};
 
 use crate::{
-    add::add_liquidity, new_definition::new_definition, remove::remove_liquidity, swap::swap,
+    add::add_liquidity, new_definition::new_definition, recover::recover_surplus,
+    remove::remove_liquidity, swap::swap,
 };
 
 const TOKEN_PROGRAM_ID: ProgramId = [15; 8];
@@ -1811,4 +1812,106 @@ fn test_new_definition_lp_symmetric_amounts() {
     )]);
 
     assert_eq!(chained_call_lp, expected_lp_call);
+}
+
+#[test]
+fn test_recover_surplus_inactive_pool_transfers_only_surplus() {
+    let donation_a = 25u128;
+
+    let mut donated_vault_a = AccountWithMetadataForTests::vault_a_init();
+    donated_vault_a.account.data = Data::from(&TokenHolding::Fungible {
+        definition_id: IdForTests::token_a_definition_id(),
+        balance: BalanceForTests::vault_a_reserve_init() + donation_a,
+    });
+
+    let (post_states, chained_calls) = recover_surplus(
+        AccountWithMetadataForTests::pool_definition_inactive(),
+        donated_vault_a.clone(),
+        AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::user_holding_a(),
+        AccountWithMetadataForTests::user_holding_b(),
+        RecoverSurplusMode::InactiveOrZeroSupplyOnly,
+    );
+
+    let pool_post = PoolDefinition::try_from(&post_states[0].account().data).unwrap();
+    assert_eq!(pool_post.reserve_a, BalanceForTests::vault_a_reserve_init());
+    assert_eq!(pool_post.reserve_b, BalanceForTests::vault_b_reserve_init());
+
+    assert_eq!(chained_calls.len(), 1);
+
+    let mut donated_vault_a_auth = donated_vault_a;
+    donated_vault_a_auth.is_authorized = true;
+    let expected_call = ChainedCall::new(
+        TOKEN_PROGRAM_ID,
+        vec![
+            donated_vault_a_auth,
+            AccountWithMetadataForTests::user_holding_a(),
+        ],
+        &token_core::Instruction::Transfer {
+            amount_to_transfer: donation_a,
+        },
+    )
+    .with_pda_seeds(vec![compute_vault_pda_seed(
+        IdForTests::pool_definition_id(),
+        IdForTests::token_a_definition_id(),
+    )]);
+
+    assert_eq!(chained_calls[0], expected_call);
+}
+
+#[should_panic(expected = "Recover surplus is only allowed for inactive or zero-supply pools")]
+#[test]
+fn test_recover_surplus_forbidden_for_active_pool() {
+    let mut donated_vault_a = AccountWithMetadataForTests::vault_a_init();
+    donated_vault_a.account.data = Data::from(&TokenHolding::Fungible {
+        definition_id: IdForTests::token_a_definition_id(),
+        balance: BalanceForTests::vault_a_reserve_init() + 1,
+    });
+
+    let _ = recover_surplus(
+        AccountWithMetadataForTests::pool_definition_init(),
+        donated_vault_a,
+        AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::user_holding_a(),
+        AccountWithMetadataForTests::user_holding_b(),
+        RecoverSurplusMode::InactiveOrZeroSupplyOnly,
+    );
+}
+
+#[should_panic(expected = "Vault A token definition mismatch")]
+#[test]
+fn test_recover_surplus_panics_when_vault_a_definition_mismatches_pool() {
+    let mut wrong_vault_a = AccountWithMetadataForTests::vault_a_init();
+    wrong_vault_a.account.data = Data::from(&TokenHolding::Fungible {
+        definition_id: IdForTests::token_b_definition_id(),
+        balance: BalanceForTests::vault_a_reserve_init(),
+    });
+
+    let _ = recover_surplus(
+        AccountWithMetadataForTests::pool_definition_inactive(),
+        wrong_vault_a,
+        AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::user_holding_a(),
+        AccountWithMetadataForTests::user_holding_b(),
+        RecoverSurplusMode::InactiveOrZeroSupplyOnly,
+    );
+}
+
+#[should_panic(expected = "Recover surplus: vault A balance is less than its reserve")]
+#[test]
+fn test_recover_surplus_panics_when_vault_a_under_collateralized() {
+    let mut undercollateralized_vault_a = AccountWithMetadataForTests::vault_a_init();
+    undercollateralized_vault_a.account.data = Data::from(&TokenHolding::Fungible {
+        definition_id: IdForTests::token_a_definition_id(),
+        balance: BalanceForTests::vault_a_reserve_init() - 1,
+    });
+
+    let _ = recover_surplus(
+        AccountWithMetadataForTests::pool_definition_inactive(),
+        undercollateralized_vault_a,
+        AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::user_holding_a(),
+        AccountWithMetadataForTests::user_holding_b(),
+        RecoverSurplusMode::InactiveOrZeroSupplyOnly,
+    );
 }

--- a/amm/src/vault_utils.rs
+++ b/amm/src/vault_utils.rs
@@ -1,0 +1,16 @@
+use nssa_core::account::{AccountId, AccountWithMetadata};
+
+pub fn read_fungible_holding(account: &AccountWithMetadata, context: &str) -> (AccountId, u128) {
+    let token_holding = token_core::TokenHolding::try_from(&account.account.data)
+        .unwrap_or_else(|_| panic!("{context}: AMM Program expects a valid Token Holding Account"));
+
+    let token_core::TokenHolding::Fungible {
+        definition_id,
+        balance,
+    } = token_holding
+    else {
+        panic!("{context}: AMM Program expects a valid Fungible Token Holding Account");
+    };
+
+    (definition_id, balance)
+}


### PR DESCRIPTION
## Summary

This PR adds a `RecoverSurplus` instruction to the AMM so vault balances above the tracked reserves can be explicitly transferred out without changing pool reserve accounting.

The implementation is scoped to non-reserve-backed balances only and includes the validation needed to keep recovery bounded to the correct token accounts and pool states.

## Changes

- add `RecoverSurplus` and `RecoverSurplusMode` to AMM core types
- add the guest entrypoint for `recover_surplus`
- add AMM surplus-recovery logic that computes and transfers only vault surplus
- validate vault and recipient token definitions before recovery
- restrict the initial recovery mode to inactive or zero-supply pools
- add focused AMM unit coverage for success, active-pool rejection, definition mismatch, and under-collateralized vault failures
- update the checked-in AMM IDL to include the new instruction and mode enum

## Testing

- `cargo +nightly fmt --all -- --check`
- `taplo fmt --check .`
- `RISC0_SKIP_BUILD=1 cargo +1.94.0 clippy --workspace --all-targets -- -D warnings`
- `RISC0_DEV_MODE=1 cargo +1.94.0 test --workspace --exclude integration_tests`
- `RISC0_DEV_MODE=1 cargo +1.94.0 test -p integration_tests`

## Notes

- `RecoverSurplus` leaves the pool’s stored reserves unchanged because it transfers only balances above those reserves.
- The initial mode intentionally keeps recovery unavailable for active pools with live LP supply.
- The implementation includes the follow-up fix that validates vault token definitions before recovery proceeds.