### PR TITLE
feat(amm): route user deposits and LP burns through ATA program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,7 @@ name = "amm_program"
 version = "0.1.0"
 dependencies = [
  "amm_core",
+ "ata_core",
  "nssa_core",
  "token_core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,14 @@ members = [
     "ata",
     "ata/methods",
     "integration_tests",
+    "integration_tests/malicious_ata_methods",
     "tools/idl-gen",
 ]
 exclude = [
     "token/methods/guest",
     "amm/methods/guest",
     "ata/methods/guest",
+    "integration_tests/malicious_ata_methods/guest",
 ]
 resolver = "2"
 

--- a/amm/Cargo.toml
+++ b/amm/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 [dependencies]
 nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1", features = ["host"] }
 amm_core = { path = "core" }
+ata_core = { path = "../ata/core" }
 token_core = { path = "../token/core" }

--- a/amm/core/src/lib.rs
+++ b/amm/core/src/lib.rs
@@ -44,13 +44,15 @@ pub enum Instruction {
     /// - Vault Holding Account for Token A (initialized)
     /// - Vault Holding Account for Token B (initialized)
     /// - Pool Liquidity Token Definition (initialized)
-    /// - User Holding Account for Token A (authorized)
-    /// - User Holding Account for Token B (authorized)
-    /// - User Holding Account for Pool Liquidity
+    /// - Owner account (authorized)
+    /// - User ATA for Token A
+    /// - User ATA for Token B
+    /// - User ATA for Pool Liquidity
     AddLiquidity {
         min_amount_liquidity: u128,
         max_amount_to_add_token_a: u128,
         max_amount_to_add_token_b: u128,
+        ata_program_id: ProgramId,
     },
 
     /// Removes liquidity from the Pool
@@ -60,13 +62,15 @@ pub enum Instruction {
     /// - Vault Holding Account for Token A (initialized)
     /// - Vault Holding Account for Token B (initialized)
     /// - Pool Liquidity Token Definition (initialized)
-    /// - User Holding Account for Token A (initialized)
-    /// - User Holding Account for Token B (initialized)
-    /// - User Holding Account for Pool Liquidity (authorized)
+    /// - Owner account (authorized)
+    /// - User ATA for Token A (initialized)
+    /// - User ATA for Token B (initialized)
+    /// - User ATA for Pool Liquidity
     RemoveLiquidity {
         remove_liquidity_amount: u128,
         min_amount_to_remove_token_a: u128,
         min_amount_to_remove_token_b: u128,
+        ata_program_id: ProgramId,
     },
 
     /// Swap some quantity of Tokens (either Token A or Token B)
@@ -76,13 +80,14 @@ pub enum Instruction {
     /// - AMM Pool (initialized)
     /// - Vault Holding Account for Token A (initialized)
     /// - Vault Holding Account for Token B (initialized)
-    /// - User Holding Account for Token A
-    /// - User Holding Account for Token B Either User Holding Account for Token A or Token B is
-    ///   authorized.
+    /// - Owner account (authorized)
+    /// - User ATA for Token A
+    /// - User ATA for Token B
     SwapExactInput {
         swap_amount_in: u128,
         min_amount_out: u128,
         token_definition_id_in: AccountId,
+        ata_program_id: ProgramId,
     },
 
     /// Swap tokens specifying the exact desired output amount,
@@ -92,13 +97,14 @@ pub enum Instruction {
     /// - AMM Pool (initialized)
     /// - Vault Holding Account for Token A (initialized)
     /// - Vault Holding Account for Token B (initialized)
-    /// - User Holding Account for Token A
-    /// - User Holding Account for Token B Either User Holding Account for Token A or Token B is
-    ///   authorized.
+    /// - Owner account (authorized)
+    /// - User ATA for Token A
+    /// - User ATA for Token B
     SwapExactOutput {
         exact_amount_out: u128,
         max_amount_in: u128,
         token_definition_id_in: AccountId,
+        ata_program_id: ProgramId,
     },
 
     /// Sync pool reserves with current vault balances.

--- a/amm/methods/guest/Cargo.lock
+++ b/amm/methods/guest/Cargo.lock
@@ -35,6 +35,7 @@ version = "0.1.0"
 dependencies = [
  "amm_core",
  "amm_program",
+ "ata_core",
  "borsh",
  "nssa_core",
  "risc0-zkvm",
@@ -59,6 +60,7 @@ name = "amm_program"
 version = "0.1.0"
 dependencies = [
  "amm_core",
+ "ata_core",
  "nssa_core",
  "token_core",
 ]
@@ -303,6 +305,16 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "ata_core"
+version = "0.1.0"
+dependencies = [
+ "borsh",
+ "nssa_core",
+ "risc0-zkvm",
+ "serde",
+]
 
 [[package]]
 name = "atomic-waker"

--- a/amm/methods/guest/Cargo.toml
+++ b/amm/methods/guest/Cargo.toml
@@ -14,6 +14,7 @@ spel-framework = { git = "https://github.com/logos-co/spel.git", tag = "v0.2.0-r
 nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1" }
 risc0-zkvm = { version = "=3.0.5", default-features = false }
 amm_core = { path = "../../core" }
+ata_core = { path = "../../../ata/core" }
 amm_program = { path = "../..", package = "amm_program" }
 token_core = { path = "../../../token/core" }
 serde = { version = "1.0", features = ["derive"] }

--- a/amm/methods/guest/src/bin/amm.rs
+++ b/amm/methods/guest/src/bin/amm.rs
@@ -56,24 +56,28 @@ mod amm {
         vault_a: AccountWithMetadata,
         vault_b: AccountWithMetadata,
         pool_definition_lp: AccountWithMetadata,
+        owner: AccountWithMetadata,
         user_holding_a: AccountWithMetadata,
         user_holding_b: AccountWithMetadata,
         user_holding_lp: AccountWithMetadata,
         min_amount_liquidity: u128,
         max_amount_to_add_token_a: u128,
         max_amount_to_add_token_b: u128,
+        ata_program_id: ProgramId,
     ) -> SpelResult {
         let (post_states, chained_calls) = amm_program::add::add_liquidity(
             pool,
             vault_a,
             vault_b,
             pool_definition_lp,
+            owner,
             user_holding_a,
             user_holding_b,
             user_holding_lp,
             NonZeroU128::new(min_amount_liquidity).expect("min_amount_liquidity must be nonzero"),
             max_amount_to_add_token_a,
             max_amount_to_add_token_b,
+            ata_program_id,
         );
         Ok(SpelOutput::with_chained_calls(post_states, chained_calls))
     }
@@ -85,18 +89,21 @@ mod amm {
         vault_a: AccountWithMetadata,
         vault_b: AccountWithMetadata,
         pool_definition_lp: AccountWithMetadata,
+        owner: AccountWithMetadata,
         user_holding_a: AccountWithMetadata,
         user_holding_b: AccountWithMetadata,
         user_holding_lp: AccountWithMetadata,
         remove_liquidity_amount: u128,
         min_amount_to_remove_token_a: u128,
         min_amount_to_remove_token_b: u128,
+        ata_program_id: ProgramId,
     ) -> SpelResult {
         let (post_states, chained_calls) = amm_program::remove::remove_liquidity(
             pool,
             vault_a,
             vault_b,
             pool_definition_lp,
+            owner,
             user_holding_a,
             user_holding_b,
             user_holding_lp,
@@ -104,6 +111,7 @@ mod amm {
                 .expect("remove_liquidity_amount must be nonzero"),
             min_amount_to_remove_token_a,
             min_amount_to_remove_token_b,
+            ata_program_id,
         );
         Ok(SpelOutput::with_chained_calls(post_states, chained_calls))
     }
@@ -114,21 +122,25 @@ mod amm {
         pool: AccountWithMetadata,
         vault_a: AccountWithMetadata,
         vault_b: AccountWithMetadata,
+        owner: AccountWithMetadata,
         user_holding_a: AccountWithMetadata,
         user_holding_b: AccountWithMetadata,
         swap_amount_in: u128,
         min_amount_out: u128,
         token_definition_id_in: AccountId,
+        ata_program_id: ProgramId,
     ) -> SpelResult {
         let (post_states, chained_calls) = amm_program::swap::swap_exact_input(
             pool,
             vault_a,
             vault_b,
+            owner,
             user_holding_a,
             user_holding_b,
             swap_amount_in,
             min_amount_out,
             token_definition_id_in,
+            ata_program_id,
         );
         Ok(SpelOutput::with_chained_calls(post_states, chained_calls))
     }
@@ -139,21 +151,25 @@ mod amm {
         pool: AccountWithMetadata,
         vault_a: AccountWithMetadata,
         vault_b: AccountWithMetadata,
+        owner: AccountWithMetadata,
         user_holding_a: AccountWithMetadata,
         user_holding_b: AccountWithMetadata,
         exact_amount_out: u128,
         max_amount_in: u128,
         token_definition_id_in: AccountId,
+        ata_program_id: ProgramId,
     ) -> SpelResult {
         let (post_states, chained_calls) = amm_program::swap::swap_exact_output(
             pool,
             vault_a,
             vault_b,
+            owner,
             user_holding_a,
             user_holding_b,
             exact_amount_out,
             max_amount_in,
             token_definition_id_in,
+            ata_program_id,
         );
         Ok(SpelOutput::with_chained_calls(post_states, chained_calls))
     }

--- a/amm/src/add.rs
+++ b/amm/src/add.rs
@@ -6,7 +6,7 @@ use amm_core::{
 };
 use nssa_core::{
     account::{AccountWithMetadata, Data},
-    program::{AccountPostState, ChainedCall},
+    program::{AccountPostState, ChainedCall, ProgramId},
 };
 
 #[expect(clippy::too_many_arguments, reason = "TODO: Fix later")]
@@ -15,12 +15,14 @@ pub fn add_liquidity(
     vault_a: AccountWithMetadata,
     vault_b: AccountWithMetadata,
     pool_definition_lp: AccountWithMetadata,
+    owner: AccountWithMetadata,
     user_holding_a: AccountWithMetadata,
     user_holding_b: AccountWithMetadata,
     user_holding_lp: AccountWithMetadata,
     min_amount_liquidity: NonZeroU128,
     max_amount_to_add_token_a: u128,
     max_amount_to_add_token_b: u128,
+    ata_program_id: ProgramId,
 ) -> (Vec<AccountPostState>, Vec<ChainedCall>) {
     // 1. Fetch Pool state
     let pool_def_data = PoolDefinition::try_from(&pool.account.data)
@@ -138,25 +140,27 @@ pub fn add_liquidity(
     };
 
     pool_post.data = Data::from(&pool_post_definition);
-    let token_program_id = user_holding_a.account.program_owner;
+    let token_program_id = vault_a.account.program_owner;
 
-    // Chain call for Token A (UserHoldingA -> Vault_A)
+    // Chain call for Token A (owner's ATA -> Vault_A via ATA program)
     let call_token_a = ChainedCall::new(
-        token_program_id,
-        vec![user_holding_a.clone(), vault_a.clone()],
-        &token_core::Instruction::Transfer {
-            amount_to_transfer: actual_amount_a,
+        ata_program_id,
+        vec![owner.clone(), user_holding_a.clone(), vault_a.clone()],
+        &ata_core::Instruction::Transfer {
+            ata_program_id,
+            amount: actual_amount_a,
         },
     );
-    // Chain call for Token B (UserHoldingB -> Vault_B)
+    // Chain call for Token B (owner's ATA -> Vault_B via ATA program)
     let call_token_b = ChainedCall::new(
-        token_program_id,
-        vec![user_holding_b.clone(), vault_b.clone()],
-        &token_core::Instruction::Transfer {
-            amount_to_transfer: actual_amount_b,
+        ata_program_id,
+        vec![owner.clone(), user_holding_b.clone(), vault_b.clone()],
+        &ata_core::Instruction::Transfer {
+            ata_program_id,
+            amount: actual_amount_b,
         },
     );
-    // Chain call for LP (mint new tokens for user_holding_lp)
+    // Chain call for LP (mint new tokens for user's LP ATA)
     let mut pool_definition_lp_auth = pool_definition_lp.clone();
     pool_definition_lp_auth.is_authorized = true;
     let call_token_lp = ChainedCall::new(
@@ -175,6 +179,7 @@ pub fn add_liquidity(
         AccountPostState::new(vault_a.account.clone()),
         AccountPostState::new(vault_b.account.clone()),
         AccountPostState::new(pool_definition_lp.account.clone()),
+        AccountPostState::new(owner.account.clone()),
         AccountPostState::new(user_holding_a.account.clone()),
         AccountPostState::new(user_holding_b.account.clone()),
         AccountPostState::new(user_holding_lp.account.clone()),

--- a/amm/src/remove.rs
+++ b/amm/src/remove.rs
@@ -1,12 +1,11 @@
 use std::num::NonZeroU128;
 
 use amm_core::{
-    assert_supported_fee_tier, compute_liquidity_token_pda_seed, compute_vault_pda_seed,
-    PoolDefinition, MINIMUM_LIQUIDITY,
+    assert_supported_fee_tier, compute_vault_pda_seed, PoolDefinition, MINIMUM_LIQUIDITY,
 };
 use nssa_core::{
     account::{AccountWithMetadata, Data},
-    program::{AccountPostState, ChainedCall},
+    program::{AccountPostState, ChainedCall, ProgramId},
 };
 
 #[expect(clippy::too_many_arguments, reason = "TODO: Fix later")]
@@ -15,12 +14,14 @@ pub fn remove_liquidity(
     vault_a: AccountWithMetadata,
     vault_b: AccountWithMetadata,
     pool_definition_lp: AccountWithMetadata,
+    owner: AccountWithMetadata,
     user_holding_a: AccountWithMetadata,
     user_holding_b: AccountWithMetadata,
     user_holding_lp: AccountWithMetadata,
     remove_liquidity_amount: NonZeroU128,
     min_amount_to_remove_token_a: u128,
     min_amount_to_remove_token_b: u128,
+    ata_program_id: ProgramId,
 ) -> (Vec<AccountPostState>, Vec<ChainedCall>) {
     let remove_liquidity_amount: u128 = remove_liquidity_amount.into();
 
@@ -143,9 +144,9 @@ pub fn remove_liquidity(
 
     pool_post.data = Data::from(&pool_post_definition);
 
-    let token_program_id = user_holding_a.account.program_owner;
+    let token_program_id = vault_a.account.program_owner;
 
-    // Chaincall for Token A withdraw
+    // Chaincall for Token A withdraw (vault PDA -> user's ATA)
     let call_token_a = ChainedCall::new(
         token_program_id,
         vec![running_vault_a, user_holding_a.clone()],
@@ -157,7 +158,7 @@ pub fn remove_liquidity(
         pool.account_id,
         pool_def_data.definition_token_a_id,
     )]);
-    // Chaincall for Token B withdraw
+    // Chaincall for Token B withdraw (vault PDA -> user's ATA)
     let call_token_b = ChainedCall::new(
         token_program_id,
         vec![running_vault_b, user_holding_b.clone()],
@@ -169,17 +170,19 @@ pub fn remove_liquidity(
         pool.account_id,
         pool_def_data.definition_token_b_id,
     )]);
-    // Chaincall for LP adjustment
-    let mut pool_definition_lp_auth = pool_definition_lp.clone();
-    pool_definition_lp_auth.is_authorized = true;
+    // Chaincall for LP burn (owner's LP ATA -> burn via ATA program)
     let call_token_lp = ChainedCall::new(
-        token_program_id,
-        vec![pool_definition_lp_auth, user_holding_lp.clone()],
-        &token_core::Instruction::Burn {
-            amount_to_burn: delta_lp,
+        ata_program_id,
+        vec![
+            owner.clone(),
+            user_holding_lp.clone(),
+            pool_definition_lp.clone(),
+        ],
+        &ata_core::Instruction::Burn {
+            ata_program_id,
+            amount: delta_lp,
         },
-    )
-    .with_pda_seeds(vec![compute_liquidity_token_pda_seed(pool.account_id)]);
+    );
 
     let chained_calls = vec![call_token_lp, call_token_b, call_token_a];
 
@@ -188,6 +191,7 @@ pub fn remove_liquidity(
         AccountPostState::new(vault_a.account.clone()),
         AccountPostState::new(vault_b.account.clone()),
         AccountPostState::new(pool_definition_lp.account.clone()),
+        AccountPostState::new(owner.account.clone()),
         AccountPostState::new(user_holding_a.account.clone()),
         AccountPostState::new(user_holding_b.account.clone()),
         AccountPostState::new(user_holding_lp.account.clone()),

--- a/amm/src/swap.rs
+++ b/amm/src/swap.rs
@@ -4,7 +4,7 @@ use amm_core::{
 pub use amm_core::{compute_liquidity_token_pda_seed, compute_vault_pda_seed, PoolDefinition};
 use nssa_core::{
     account::{AccountId, AccountWithMetadata, Data},
-    program::{AccountPostState, ChainedCall},
+    program::{AccountPostState, ChainedCall, ProgramId},
 };
 
 /// Validates swap setup: checks pool liquidity is ready, vaults match, and reserves are sufficient.
@@ -56,6 +56,7 @@ fn create_swap_post_states(
     pool_def_data: PoolDefinition,
     vault_a: AccountWithMetadata,
     vault_b: AccountWithMetadata,
+    owner: AccountWithMetadata,
     user_holding_a: AccountWithMetadata,
     user_holding_b: AccountWithMetadata,
     deposit_a: u128,
@@ -86,6 +87,7 @@ fn create_swap_post_states(
         AccountPostState::new(pool_post),
         AccountPostState::new(vault_a.account),
         AccountPostState::new(vault_b.account),
+        AccountPostState::new(owner.account),
         AccountPostState::new(user_holding_a.account),
         AccountPostState::new(user_holding_b.account),
     ]
@@ -97,17 +99,20 @@ pub fn swap_exact_input(
     pool: AccountWithMetadata,
     vault_a: AccountWithMetadata,
     vault_b: AccountWithMetadata,
+    owner: AccountWithMetadata,
     user_holding_a: AccountWithMetadata,
     user_holding_b: AccountWithMetadata,
     swap_amount_in: u128,
     min_amount_out: u128,
     token_in_id: AccountId,
+    ata_program_id: ProgramId,
 ) -> (Vec<AccountPostState>, Vec<ChainedCall>) {
     let pool_def_data = validate_swap_setup(&pool, &vault_a, &vault_b);
 
     let (chained_calls, [deposit_a, withdraw_a], [deposit_b, withdraw_b]) =
         if token_in_id == pool_def_data.definition_token_a_id {
             let (chained_calls, deposit_a, withdraw_b) = swap_logic(
+                owner.clone(),
                 user_holding_a.clone(),
                 vault_a.clone(),
                 vault_b.clone(),
@@ -118,11 +123,13 @@ pub fn swap_exact_input(
                 pool_def_data.reserve_a,
                 pool_def_data.reserve_b,
                 pool.account_id,
+                ata_program_id,
             );
 
             (chained_calls, [deposit_a, 0], [0, withdraw_b])
         } else if token_in_id == pool_def_data.definition_token_b_id {
             let (chained_calls, deposit_b, withdraw_a) = swap_logic(
+                owner.clone(),
                 user_holding_b.clone(),
                 vault_b.clone(),
                 vault_a.clone(),
@@ -133,6 +140,7 @@ pub fn swap_exact_input(
                 pool_def_data.reserve_b,
                 pool_def_data.reserve_a,
                 pool.account_id,
+                ata_program_id,
             );
 
             (chained_calls, [0, withdraw_a], [deposit_b, 0])
@@ -145,6 +153,7 @@ pub fn swap_exact_input(
         pool_def_data,
         vault_a,
         vault_b,
+        owner,
         user_holding_a,
         user_holding_b,
         deposit_a,
@@ -158,6 +167,7 @@ pub fn swap_exact_input(
 
 #[expect(clippy::too_many_arguments, reason = "TODO: Fix later")]
 fn swap_logic(
+    owner: AccountWithMetadata,
     user_deposit: AccountWithMetadata,
     vault_deposit: AccountWithMetadata,
     vault_withdraw: AccountWithMetadata,
@@ -168,6 +178,7 @@ fn swap_logic(
     reserve_deposit_vault_amount: u128,
     reserve_withdraw_vault_amount: u128,
     pool_id: AccountId,
+    ata_program_id: ProgramId,
 ) -> (Vec<ChainedCall>, u128, u128) {
     let effective_amount_in = swap_amount_in
         .checked_mul(FEE_BPS_DENOMINATOR - fee_bps)
@@ -195,14 +206,16 @@ fn swap_logic(
     );
     assert!(withdraw_amount != 0, "Withdraw amount should be nonzero");
 
-    let token_program_id = user_deposit.account.program_owner;
+    let token_program_id = vault_withdraw.account.program_owner;
 
     let mut chained_calls = Vec::new();
+    // Deposit: owner's ATA -> vault via ATA program
     chained_calls.push(ChainedCall::new(
-        token_program_id,
-        vec![user_deposit, vault_deposit],
-        &token_core::Instruction::Transfer {
-            amount_to_transfer: swap_amount_in,
+        ata_program_id,
+        vec![owner, user_deposit, vault_deposit],
+        &ata_core::Instruction::Transfer {
+            ata_program_id,
+            amount: swap_amount_in,
         },
     ));
 
@@ -216,6 +229,7 @@ fn swap_logic(
             .definition_id(),
     );
 
+    // Withdrawal: vault PDA -> user's ATA (no ATA auth needed for recipient)
     chained_calls.push(
         ChainedCall::new(
             token_program_id,
@@ -236,17 +250,20 @@ pub fn swap_exact_output(
     pool: AccountWithMetadata,
     vault_a: AccountWithMetadata,
     vault_b: AccountWithMetadata,
+    owner: AccountWithMetadata,
     user_holding_a: AccountWithMetadata,
     user_holding_b: AccountWithMetadata,
     exact_amount_out: u128,
     max_amount_in: u128,
     token_in_id: AccountId,
+    ata_program_id: ProgramId,
 ) -> (Vec<AccountPostState>, Vec<ChainedCall>) {
     let pool_def_data = validate_swap_setup(&pool, &vault_a, &vault_b);
 
     let (chained_calls, [deposit_a, withdraw_a], [deposit_b, withdraw_b]) =
         if token_in_id == pool_def_data.definition_token_a_id {
             let (chained_calls, deposit_a, withdraw_b) = exact_output_swap_logic(
+                owner.clone(),
                 user_holding_a.clone(),
                 vault_a.clone(),
                 vault_b.clone(),
@@ -257,11 +274,13 @@ pub fn swap_exact_output(
                 pool_def_data.reserve_b,
                 pool_def_data.fees,
                 pool.account_id,
+                ata_program_id,
             );
 
             (chained_calls, [deposit_a, 0], [0, withdraw_b])
         } else if token_in_id == pool_def_data.definition_token_b_id {
             let (chained_calls, deposit_b, withdraw_a) = exact_output_swap_logic(
+                owner.clone(),
                 user_holding_b.clone(),
                 vault_b.clone(),
                 vault_a.clone(),
@@ -272,6 +291,7 @@ pub fn swap_exact_output(
                 pool_def_data.reserve_a,
                 pool_def_data.fees,
                 pool.account_id,
+                ata_program_id,
             );
 
             (chained_calls, [0, withdraw_a], [deposit_b, 0])
@@ -284,6 +304,7 @@ pub fn swap_exact_output(
         pool_def_data,
         vault_a,
         vault_b,
+        owner,
         user_holding_a,
         user_holding_b,
         deposit_a,
@@ -297,6 +318,7 @@ pub fn swap_exact_output(
 
 #[expect(clippy::too_many_arguments, reason = "TODO: Fix later")]
 fn exact_output_swap_logic(
+    owner: AccountWithMetadata,
     user_deposit: AccountWithMetadata,
     vault_deposit: AccountWithMetadata,
     vault_withdraw: AccountWithMetadata,
@@ -307,6 +329,7 @@ fn exact_output_swap_logic(
     reserve_withdraw_vault_amount: u128,
     fee_bps: u128,
     pool_id: AccountId,
+    ata_program_id: ProgramId,
 ) -> (Vec<ChainedCall>, u128, u128) {
     // Guard: exact_amount_out must be nonzero
     assert_ne!(exact_amount_out, 0, "Exact amount out must be nonzero");
@@ -346,14 +369,16 @@ fn exact_output_swap_logic(
         "Required input exceeds maximum amount in"
     );
 
-    let token_program_id = user_deposit.account.program_owner;
+    let token_program_id = vault_withdraw.account.program_owner;
 
     let mut chained_calls = Vec::new();
+    // Deposit: owner's ATA -> vault via ATA program
     chained_calls.push(ChainedCall::new(
-        token_program_id,
-        vec![user_deposit, vault_deposit],
-        &token_core::Instruction::Transfer {
-            amount_to_transfer: deposit_amount,
+        ata_program_id,
+        vec![owner, user_deposit, vault_deposit],
+        &ata_core::Instruction::Transfer {
+            ata_program_id,
+            amount: deposit_amount,
         },
     ));
 
@@ -367,6 +392,7 @@ fn exact_output_swap_logic(
             .definition_id(),
     );
 
+    // Withdrawal: vault PDA -> user's ATA (no ATA auth needed for recipient)
     chained_calls.push(
         ChainedCall::new(
             token_program_id,

--- a/amm/src/tests.rs
+++ b/amm/src/tests.rs
@@ -24,6 +24,7 @@ use crate::{
 
 const TOKEN_PROGRAM_ID: ProgramId = [15; 8];
 const AMM_PROGRAM_ID: ProgramId = [42; 8];
+const ATA_PROGRAM_ID: ProgramId = [99; 8];
 
 struct BalanceForTests;
 struct ChainedCallForTests;
@@ -224,13 +225,15 @@ impl BalanceForTests {
 impl ChainedCallForTests {
     fn cc_swap_token_a_test_1() -> ChainedCall {
         ChainedCall::new(
-            TOKEN_PROGRAM_ID,
+            ATA_PROGRAM_ID,
             vec![
+                AccountWithMetadataForTests::owner(),
                 AccountWithMetadataForTests::user_holding_a(),
                 AccountWithMetadataForTests::vault_a_init(),
             ],
-            &token_core::Instruction::Transfer {
-                amount_to_transfer: BalanceForTests::add_max_amount_a(),
+            &ata_core::Instruction::Transfer {
+                ata_program_id: ATA_PROGRAM_ID,
+                amount: BalanceForTests::add_max_amount_a(),
             },
         )
     }
@@ -275,13 +278,15 @@ impl ChainedCallForTests {
 
     fn cc_swap_token_b_test_2() -> ChainedCall {
         ChainedCall::new(
-            TOKEN_PROGRAM_ID,
+            ATA_PROGRAM_ID,
             vec![
+                AccountWithMetadataForTests::owner(),
                 AccountWithMetadataForTests::user_holding_b(),
                 AccountWithMetadataForTests::vault_b_init(),
             ],
-            &token_core::Instruction::Transfer {
-                amount_to_transfer: BalanceForTests::add_max_amount_b(),
+            &ata_core::Instruction::Transfer {
+                ata_program_id: ATA_PROGRAM_ID,
+                amount: BalanceForTests::add_max_amount_b(),
             },
         )
     }
@@ -293,13 +298,15 @@ impl ChainedCallForTests {
         let swap_amount: u128 = 500;
 
         ChainedCall::new(
-            TOKEN_PROGRAM_ID,
+            ATA_PROGRAM_ID,
             vec![
+                AccountWithMetadataForTests::owner(),
                 AccountWithMetadataForTests::user_holding_a(),
                 AccountWithMetadataForTests::vault_a_init(),
             ],
-            &token_core::Instruction::Transfer {
-                amount_to_transfer: swap_amount,
+            &ata_core::Instruction::Transfer {
+                ata_program_id: ATA_PROGRAM_ID,
+                amount: swap_amount,
             },
         )
     }
@@ -349,26 +356,30 @@ impl ChainedCallForTests {
         let swap_amount: u128 = 201;
 
         ChainedCall::new(
-            TOKEN_PROGRAM_ID,
+            ATA_PROGRAM_ID,
             vec![
+                AccountWithMetadataForTests::owner(),
                 AccountWithMetadataForTests::user_holding_b(),
                 AccountWithMetadataForTests::vault_b_init(),
             ],
-            &token_core::Instruction::Transfer {
-                amount_to_transfer: swap_amount,
+            &ata_core::Instruction::Transfer {
+                ata_program_id: ATA_PROGRAM_ID,
+                amount: swap_amount,
             },
         )
     }
 
     fn cc_swap_rounding_boundary_token_a_in() -> ChainedCall {
         ChainedCall::new(
-            TOKEN_PROGRAM_ID,
+            ATA_PROGRAM_ID,
             vec![
+                AccountWithMetadataForTests::owner(),
                 AccountWithMetadataForTests::user_holding_a(),
                 AccountWithMetadataForTests::vault_a_init(),
             ],
-            &token_core::Instruction::Transfer {
-                amount_to_transfer: 3,
+            &ata_core::Instruction::Transfer {
+                ata_program_id: ATA_PROGRAM_ID,
+                amount: 3,
             },
         )
     }
@@ -392,26 +403,30 @@ impl ChainedCallForTests {
 
     fn cc_add_token_a() -> ChainedCall {
         ChainedCall::new(
-            TOKEN_PROGRAM_ID,
+            ATA_PROGRAM_ID,
             vec![
+                AccountWithMetadataForTests::owner(),
                 AccountWithMetadataForTests::user_holding_a(),
                 AccountWithMetadataForTests::vault_a_init(),
             ],
-            &token_core::Instruction::Transfer {
-                amount_to_transfer: BalanceForTests::add_successful_amount_a(),
+            &ata_core::Instruction::Transfer {
+                ata_program_id: ATA_PROGRAM_ID,
+                amount: BalanceForTests::add_successful_amount_a(),
             },
         )
     }
 
     fn cc_add_token_b() -> ChainedCall {
         ChainedCall::new(
-            TOKEN_PROGRAM_ID,
+            ATA_PROGRAM_ID,
             vec![
+                AccountWithMetadataForTests::owner(),
                 AccountWithMetadataForTests::user_holding_b(),
                 AccountWithMetadataForTests::vault_b_init(),
             ],
-            &token_core::Instruction::Transfer {
-                amount_to_transfer: BalanceForTests::add_successful_amount_b(),
+            &ata_core::Instruction::Transfer {
+                ata_program_id: ATA_PROGRAM_ID,
+                amount: BalanceForTests::add_successful_amount_b(),
             },
         )
     }
@@ -470,22 +485,18 @@ impl ChainedCallForTests {
     }
 
     fn cc_remove_pool_lp() -> ChainedCall {
-        let mut pool_lp_auth = AccountWithMetadataForTests::pool_lp_init();
-        pool_lp_auth.is_authorized = true;
-
         ChainedCall::new(
-            TOKEN_PROGRAM_ID,
+            ATA_PROGRAM_ID,
             vec![
-                pool_lp_auth,
+                AccountWithMetadataForTests::owner(),
                 AccountWithMetadataForTests::user_holding_lp_init(),
+                AccountWithMetadataForTests::pool_lp_init(),
             ],
-            &token_core::Instruction::Burn {
-                amount_to_burn: BalanceForTests::remove_amount_lp(),
+            &ata_core::Instruction::Burn {
+                ata_program_id: ATA_PROGRAM_ID,
+                amount: BalanceForTests::remove_amount_lp(),
             },
         )
-        .with_pda_seeds(vec![compute_liquidity_token_pda_seed(
-            IdForTests::pool_definition_id(),
-        )])
     }
 
     fn cc_new_definition_token_a() -> ChainedCall {
@@ -610,6 +621,10 @@ impl IdForTests {
             IdForTests::pool_definition_id(),
             IdForTests::token_b_definition_id(),
         )
+    }
+
+    fn owner_id() -> AccountId {
+        AccountId::new([48; 32])
     }
 }
 
@@ -1370,6 +1385,19 @@ impl AccountWithMetadataForTests {
             account_id: IdForTests::pool_definition_id(),
         }
     }
+
+    fn owner() -> AccountWithMetadata {
+        AccountWithMetadata {
+            account: Account {
+                program_owner: ProgramId::default(),
+                balance: 0u128,
+                data: Data::default(),
+                nonce: Nonce(0),
+            },
+            is_authorized: true,
+            account_id: IdForTests::owner_id(),
+        }
+    }
 }
 
 #[test]
@@ -1395,12 +1423,14 @@ fn test_call_add_liquidity_vault_a_omitted() {
         AccountWithMetadataForTests::vault_a_with_wrong_id(),
         AccountWithMetadataForTests::vault_b_init(),
         AccountWithMetadataForTests::pool_lp_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         AccountWithMetadataForTests::user_holding_lp_init(),
         NonZero::new(BalanceForTests::add_min_amount_lp()).unwrap(),
         BalanceForTests::add_max_amount_a(),
         BalanceForTests::add_max_amount_b(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -1412,12 +1442,14 @@ fn test_call_add_liquidity_vault_b_omitted() {
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_with_wrong_id(),
         AccountWithMetadataForTests::pool_lp_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         AccountWithMetadataForTests::user_holding_lp_init(),
         NonZero::new(BalanceForTests::add_min_amount_lp()).unwrap(),
         BalanceForTests::add_max_amount_a(),
         BalanceForTests::add_max_amount_b(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -1429,12 +1461,14 @@ fn test_call_add_liquidity_lp_definition_mismatch() {
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
         AccountWithMetadataForTests::pool_lp_with_wrong_id(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         AccountWithMetadataForTests::user_holding_lp_init(),
         NonZero::new(BalanceForTests::add_min_amount_lp()).unwrap(),
         BalanceForTests::add_max_amount_a(),
         BalanceForTests::add_max_amount_b(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -1446,12 +1480,14 @@ fn test_call_add_liquidity_zero_balance_1() {
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
         AccountWithMetadataForTests::pool_lp_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         AccountWithMetadataForTests::user_holding_lp_init(),
         NonZero::new(BalanceForTests::add_min_amount_lp()).unwrap(),
         0,
         BalanceForTests::add_max_amount_b(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -1463,12 +1499,14 @@ fn test_call_add_liquidity_zero_balance_2() {
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
         AccountWithMetadataForTests::pool_lp_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         AccountWithMetadataForTests::user_holding_lp_init(),
         NonZero::new(BalanceForTests::add_min_amount_lp()).unwrap(),
         0,
         BalanceForTests::add_max_amount_a(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -1480,12 +1518,14 @@ fn test_call_add_liquidity_vault_a_balance_below_reserve() {
         AccountWithMetadataForTests::vault_a_init_low(),
         AccountWithMetadataForTests::vault_b_init(),
         AccountWithMetadataForTests::pool_lp_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         AccountWithMetadataForTests::user_holding_lp_init(),
         NonZero::new(BalanceForTests::add_min_amount_lp()).unwrap(),
         BalanceForTests::add_max_amount_a(),
         BalanceForTests::add_max_amount_b(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -1497,12 +1537,14 @@ fn test_call_add_liquidity_vault_b_balance_below_reserve() {
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init_low(),
         AccountWithMetadataForTests::pool_lp_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         AccountWithMetadataForTests::user_holding_lp_init(),
         NonZero::new(BalanceForTests::add_min_amount_lp()).unwrap(),
         BalanceForTests::add_max_amount_a(),
         BalanceForTests::add_max_amount_b(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -1514,12 +1556,14 @@ fn test_call_add_liquidity_vault_insufficient_balance_1() {
         AccountWithMetadataForTests::vault_a_init_zero(),
         AccountWithMetadataForTests::vault_b_init(),
         AccountWithMetadataForTests::pool_lp_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         AccountWithMetadataForTests::user_holding_lp_init(),
         NonZero::new(BalanceForTests::add_min_amount_lp()).unwrap(),
         BalanceForTests::add_max_amount_a(),
         BalanceForTests::add_max_amount_b(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -1531,12 +1575,14 @@ fn test_call_add_liquidity_vault_insufficient_balance_2() {
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init_zero(),
         AccountWithMetadataForTests::pool_lp_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         AccountWithMetadataForTests::user_holding_lp_init(),
         NonZero::new(BalanceForTests::add_min_amount_lp()).unwrap(),
         BalanceForTests::add_max_amount_a(),
         BalanceForTests::add_max_amount_b(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -1548,12 +1594,14 @@ fn test_call_add_liquidity_actual_amount_zero_1() {
         AccountWithMetadataForTests::vault_a_init_low(),
         AccountWithMetadataForTests::vault_b_init_high(),
         AccountWithMetadataForTests::pool_lp_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         AccountWithMetadataForTests::user_holding_lp_init(),
         NonZero::new(BalanceForTests::add_min_amount_lp()).unwrap(),
         BalanceForTests::add_max_amount_a(),
         BalanceForTests::add_max_amount_b(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -1565,12 +1613,14 @@ fn test_call_add_liquidity_actual_amount_zero_2() {
         AccountWithMetadataForTests::vault_a_init_high(),
         AccountWithMetadataForTests::vault_b_init_low(),
         AccountWithMetadataForTests::pool_lp_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         AccountWithMetadataForTests::user_holding_lp_init(),
         NonZero::new(BalanceForTests::add_min_amount_lp()).unwrap(),
         BalanceForTests::add_max_amount_a_low(),
         BalanceForTests::add_max_amount_b_low(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -1582,12 +1632,14 @@ fn test_call_add_liquidity_reserves_zero_1() {
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
         AccountWithMetadataForTests::pool_lp_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         AccountWithMetadataForTests::user_holding_lp_init(),
         NonZero::new(BalanceForTests::add_min_amount_lp()).unwrap(),
         BalanceForTests::add_max_amount_a(),
         BalanceForTests::add_max_amount_b(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -1599,12 +1651,14 @@ fn test_call_add_liquidity_reserves_zero_2() {
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
         AccountWithMetadataForTests::pool_lp_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         AccountWithMetadataForTests::user_holding_lp_init(),
         NonZero::new(BalanceForTests::add_min_amount_lp()).unwrap(),
         BalanceForTests::add_max_amount_a(),
         BalanceForTests::add_max_amount_b(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -1616,12 +1670,14 @@ fn test_call_add_liquidity_payable_lp_zero() {
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
         AccountWithMetadataForTests::pool_lp_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         AccountWithMetadataForTests::user_holding_lp_init(),
         NonZero::new(BalanceForTests::add_min_amount_lp()).unwrap(),
         BalanceForTests::add_max_amount_a_low(),
         BalanceForTests::add_max_amount_b_low(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -1632,12 +1688,14 @@ fn test_call_add_liquidity_chained_call_successsful() {
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
         AccountWithMetadataForTests::pool_lp_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         AccountWithMetadataForTests::user_holding_lp_init(),
         NonZero::new(BalanceForTests::add_min_amount_lp()).unwrap(),
         BalanceForTests::add_max_amount_a(),
         BalanceForTests::add_max_amount_b(),
+        ATA_PROGRAM_ID,
     );
 
     let pool_post = post_states[0].clone();
@@ -1664,12 +1722,14 @@ fn test_call_remove_liquidity_vault_a_omitted() {
         AccountWithMetadataForTests::vault_a_with_wrong_id(),
         AccountWithMetadataForTests::vault_b_init(),
         AccountWithMetadataForTests::pool_lp_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         AccountWithMetadataForTests::user_holding_lp_init(),
         NonZero::new(BalanceForTests::remove_amount_lp()).unwrap(),
         BalanceForTests::remove_min_amount_a(),
         BalanceForTests::remove_min_amount_b(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -1681,12 +1741,14 @@ fn test_call_remove_liquidity_vault_b_omitted() {
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_with_wrong_id(),
         AccountWithMetadataForTests::pool_lp_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         AccountWithMetadataForTests::user_holding_lp_init(),
         NonZero::new(BalanceForTests::remove_amount_lp()).unwrap(),
         BalanceForTests::remove_min_amount_a(),
         BalanceForTests::remove_min_amount_b(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -1698,12 +1760,14 @@ fn test_call_remove_liquidity_lp_def_mismatch() {
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
         AccountWithMetadataForTests::pool_lp_with_wrong_id(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         AccountWithMetadataForTests::user_holding_lp_init(),
         NonZero::new(BalanceForTests::remove_amount_lp()).unwrap(),
         BalanceForTests::remove_min_amount_a(),
         BalanceForTests::remove_min_amount_b(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -1715,6 +1779,7 @@ fn test_call_remove_liquidity_insufficient_liquidity_amount() {
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
         AccountWithMetadataForTests::pool_lp_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         AccountWithMetadataForTests::user_holding_a(), /* different token account than lp to
@@ -1723,6 +1788,7 @@ fn test_call_remove_liquidity_insufficient_liquidity_amount() {
         NonZero::new(BalanceForTests::remove_amount_lp()).unwrap(),
         BalanceForTests::remove_min_amount_a(),
         BalanceForTests::remove_min_amount_b(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -1736,12 +1802,14 @@ fn test_call_remove_liquidity_insufficient_balance_1() {
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
         AccountWithMetadataForTests::pool_lp_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         AccountWithMetadataForTests::user_holding_lp_init(),
         NonZero::new(BalanceForTests::remove_amount_lp_1()).unwrap(),
         BalanceForTests::remove_min_amount_a(),
         BalanceForTests::remove_min_amount_b(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -1754,12 +1822,14 @@ fn test_call_remove_liquidity_pool_at_minimum_liquidity() {
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
         AccountWithMetadataForTests::pool_lp_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         AccountWithMetadataForTests::user_holding_lp_with_balance(MINIMUM_LIQUIDITY),
         NonZero::new(MINIMUM_LIQUIDITY).unwrap(),
         1,
         1,
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -1774,12 +1844,14 @@ fn test_call_remove_liquidity_exceeds_unlocked_supply() {
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
         AccountWithMetadataForTests::pool_lp_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         AccountWithMetadataForTests::user_holding_lp_with_balance(BalanceForTests::lp_supply_init()),
         NonZero::new(BalanceForTests::lp_supply_init()).unwrap(),
         1,
         1,
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -1793,12 +1865,14 @@ fn test_call_remove_liquidity_insufficient_balance_2() {
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
         AccountWithMetadataForTests::pool_lp_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         AccountWithMetadataForTests::user_holding_lp_init(),
         NonZero::new(BalanceForTests::remove_amount_lp()).unwrap(),
         BalanceForTests::remove_min_amount_a(),
         BalanceForTests::remove_min_amount_b(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -1810,12 +1884,14 @@ fn test_call_remove_liquidity_min_bal_zero_1() {
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
         AccountWithMetadataForTests::pool_lp_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         AccountWithMetadataForTests::user_holding_lp_init(),
         NonZero::new(BalanceForTests::remove_amount_lp()).unwrap(),
         0,
         BalanceForTests::remove_min_amount_b(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -1827,12 +1903,14 @@ fn test_call_remove_liquidity_min_bal_zero_2() {
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
         AccountWithMetadataForTests::pool_lp_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         AccountWithMetadataForTests::user_holding_lp_init(),
         NonZero::new(BalanceForTests::remove_amount_lp()).unwrap(),
         BalanceForTests::remove_min_amount_a(),
         0,
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -1843,12 +1921,14 @@ fn test_call_remove_liquidity_chained_call_successful() {
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
         AccountWithMetadataForTests::pool_lp_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         AccountWithMetadataForTests::user_holding_lp_init(),
         NonZero::new(BalanceForTests::remove_amount_lp()).unwrap(),
         BalanceForTests::remove_min_amount_a(),
         BalanceForTests::remove_min_amount_b_low(),
+        ATA_PROGRAM_ID,
     );
 
     let pool_post = post_states[0].clone();
@@ -2105,11 +2185,13 @@ fn test_call_swap_incorrect_token_type() {
         AccountWithMetadataForTests::pool_definition_init(),
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         BalanceForTests::add_max_amount_a(),
         BalanceForTests::min_amount_out(),
         IdForTests::token_lp_definition_id(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -2120,11 +2202,13 @@ fn test_call_swap_vault_a_omitted() {
         AccountWithMetadataForTests::pool_definition_init(),
         AccountWithMetadataForTests::vault_a_with_wrong_id(),
         AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         BalanceForTests::add_max_amount_a(),
         BalanceForTests::min_amount_out(),
         IdForTests::token_a_definition_id(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -2135,11 +2219,13 @@ fn test_call_swap_vault_b_omitted() {
         AccountWithMetadataForTests::pool_definition_init(),
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_with_wrong_id(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         BalanceForTests::add_max_amount_a(),
         BalanceForTests::min_amount_out(),
         IdForTests::token_a_definition_id(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -2150,11 +2236,13 @@ fn test_call_swap_reserves_vault_mismatch_1() {
         AccountWithMetadataForTests::pool_definition_init(),
         AccountWithMetadataForTests::vault_a_init_low(),
         AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         BalanceForTests::add_max_amount_a(),
         BalanceForTests::min_amount_out(),
         IdForTests::token_a_definition_id(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -2165,11 +2253,13 @@ fn test_call_swap_reserves_vault_mismatch_2() {
         AccountWithMetadataForTests::pool_definition_init(),
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init_low(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         BalanceForTests::add_max_amount_a(),
         BalanceForTests::min_amount_out(),
         IdForTests::token_a_definition_id(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -2180,11 +2270,13 @@ fn test_call_swap_below_minimum_liquidity() {
         AccountWithMetadataForTests::pool_definition_below_minimum_liquidity(),
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         BalanceForTests::add_max_amount_a(),
         BalanceForTests::min_amount_out(),
         IdForTests::token_a_definition_id(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -2200,11 +2292,13 @@ fn test_call_swap_rejects_unsupported_fee_tier() {
         pool,
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         BalanceForTests::add_max_amount_a(),
         BalanceForTests::add_max_amount_a_low(),
         IdForTests::token_a_definition_id(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -2215,11 +2309,13 @@ fn test_call_swap_below_min_out() {
         AccountWithMetadataForTests::pool_definition_init(),
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         BalanceForTests::add_max_amount_a(),
         BalanceForTests::min_amount_out_too_high(),
         IdForTests::token_a_definition_id(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -2230,11 +2326,13 @@ fn test_call_swap_effective_amount_zero() {
         AccountWithMetadataForTests::pool_definition_init(),
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         1,
         0,
         IdForTests::token_a_definition_id(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -2245,11 +2343,13 @@ fn test_call_swap_output_rounds_to_zero() {
         AccountWithMetadataForTests::pool_definition_init_low_balances(),
         AccountWithMetadataForTests::vault_a_init_low(),
         AccountWithMetadataForTests::vault_b_init_low(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         2,
         0,
         IdForTests::token_a_definition_id(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -2260,11 +2360,13 @@ fn test_call_swap_exact_input_rejects_amount_that_rounds_down_below_target_outpu
         AccountWithMetadataForTests::pool_definition_swap_rounding_boundary_init(),
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         2,
         1,
         IdForTests::token_a_definition_id(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -2274,11 +2376,13 @@ fn test_call_swap_exact_input_accepts_smallest_amount_for_rounded_boundary() {
         AccountWithMetadataForTests::pool_definition_swap_rounding_boundary_init(),
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         3,
         1,
         IdForTests::token_a_definition_id(),
+        ATA_PROGRAM_ID,
     );
 
     let pool_post = post_states[0].clone();
@@ -2307,11 +2411,13 @@ fn test_call_swap_chained_call_successful_1() {
         AccountWithMetadataForTests::pool_definition_init(),
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         BalanceForTests::add_max_amount_a(),
         BalanceForTests::add_max_amount_a_low(),
         IdForTests::token_a_definition_id(),
+        ATA_PROGRAM_ID,
     );
 
     let pool_post = post_states[0].clone();
@@ -2339,11 +2445,13 @@ fn test_call_swap_chained_call_successful_2() {
         AccountWithMetadataForTests::pool_definition_init(),
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         BalanceForTests::add_max_amount_b(),
         BalanceForTests::min_amount_out(),
         IdForTests::token_b_definition_id(),
+        ATA_PROGRAM_ID,
     );
 
     let pool_post = post_states[0].clone();
@@ -2372,11 +2480,13 @@ fn call_swap_exact_output_incorrect_token_type() {
         AccountWithMetadataForTests::pool_definition_init(),
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         BalanceForTests::add_max_amount_a(),
         BalanceForTests::max_amount_in(),
         IdForTests::token_lp_definition_id(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -2387,11 +2497,13 @@ fn call_swap_exact_output_vault_a_omitted() {
         AccountWithMetadataForTests::pool_definition_init(),
         AccountWithMetadataForTests::vault_a_with_wrong_id(),
         AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         BalanceForTests::add_max_amount_a(),
         BalanceForTests::max_amount_in(),
         IdForTests::token_a_definition_id(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -2402,11 +2514,13 @@ fn call_swap_exact_output_vault_b_omitted() {
         AccountWithMetadataForTests::pool_definition_init(),
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_with_wrong_id(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         BalanceForTests::add_max_amount_a(),
         BalanceForTests::max_amount_in(),
         IdForTests::token_a_definition_id(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -2417,11 +2531,13 @@ fn call_swap_exact_output_reserves_vault_mismatch_1() {
         AccountWithMetadataForTests::pool_definition_init(),
         AccountWithMetadataForTests::vault_a_init_low(),
         AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         BalanceForTests::add_max_amount_a(),
         BalanceForTests::max_amount_in(),
         IdForTests::token_a_definition_id(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -2432,11 +2548,13 @@ fn call_swap_exact_output_reserves_vault_mismatch_2() {
         AccountWithMetadataForTests::pool_definition_init(),
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init_low(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         BalanceForTests::add_max_amount_a(),
         BalanceForTests::max_amount_in(),
         IdForTests::token_a_definition_id(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -2447,11 +2565,13 @@ fn call_swap_exact_output_below_minimum_liquidity() {
         AccountWithMetadataForTests::pool_definition_below_minimum_liquidity(),
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         BalanceForTests::add_max_amount_a(),
         BalanceForTests::max_amount_in(),
         IdForTests::token_a_definition_id(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -2462,11 +2582,13 @@ fn call_swap_exact_output_exceeds_max_in() {
         AccountWithMetadataForTests::pool_definition_init(),
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         166_u128,
         100_u128,
         IdForTests::token_a_definition_id(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -2477,11 +2599,13 @@ fn call_swap_exact_output_zero() {
         AccountWithMetadataForTests::pool_definition_init(),
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         0_u128,
         500_u128,
         IdForTests::token_a_definition_id(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -2492,11 +2616,13 @@ fn call_swap_exact_output_exceeds_reserve() {
         AccountWithMetadataForTests::pool_definition_init(),
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         BalanceForTests::vault_b_reserve_init(),
         BalanceForTests::max_amount_in(),
         IdForTests::token_a_definition_id(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -2506,11 +2632,13 @@ fn call_swap_exact_output_chained_call_successful() {
         AccountWithMetadataForTests::pool_definition_swap_exact_output_init(),
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         BalanceForTests::max_amount_in(),
         BalanceForTests::vault_b_reserve_init(),
         IdForTests::token_a_definition_id(),
+        ATA_PROGRAM_ID,
     );
 
     let pool_post = post_states[0].clone();
@@ -2539,11 +2667,13 @@ fn call_swap_exact_output_chained_call_successful_2() {
         AccountWithMetadataForTests::pool_definition_swap_exact_output_init(),
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         285,
         300,
         IdForTests::token_b_definition_id(),
+        ATA_PROGRAM_ID,
     );
 
     let pool_post = post_states[0].clone();
@@ -2575,11 +2705,13 @@ fn call_swap_exact_output_fee_enforced() {
         AccountWithMetadataForTests::pool_definition_swap_exact_output_init(),
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         166_u128, // exact_amount_out: token_b
         499_u128, // max_amount_in: still one short after fee rounding
         IdForTests::token_a_definition_id(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -2593,11 +2725,13 @@ fn call_swap_exact_output_rejects_max_in_that_rounds_down_below_target_output() 
         AccountWithMetadataForTests::pool_definition_swap_rounding_boundary_init(),
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         1,
         2,
         IdForTests::token_a_definition_id(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -2607,11 +2741,13 @@ fn call_swap_exact_output_accepts_smallest_max_in_for_rounded_boundary() {
         AccountWithMetadataForTests::pool_definition_swap_rounding_boundary_init(),
         AccountWithMetadataForTests::vault_a_init(),
         AccountWithMetadataForTests::vault_b_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         1,
         3,
         IdForTests::token_a_definition_id(),
+        ATA_PROGRAM_ID,
     );
 
     let pool_post = post_states[0].clone();
@@ -2698,12 +2834,14 @@ fn swap_exact_output_overflow_protection() {
         pool,
         vault_a,
         vault_b,
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         2, // exact_amount_out: small, valid (< reserve_b)
         1, // max_amount_in: tiny — real deposit would be enormous, but
         // overflow wraps it to 0, making 0 <= 1 pass silently
         IdForTests::token_a_definition_id(),
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -2876,12 +3014,14 @@ fn test_minimum_liquidity_lock_and_remove_all_user_lp() {
         AccountForTests::vault_a_init(),
         AccountForTests::vault_b_init(),
         AccountForTests::pool_lp_init(),
+        AccountForTests::owner(),
         AccountForTests::user_holding_a(),
         AccountForTests::user_holding_b(),
         AccountForTests::user_holding_lp_with_balance(user_lp),
         NonZero::new(user_lp).unwrap(),
         1,
         1,
+        ATA_PROGRAM_ID,
     );
 
     let pool_after_remove =
@@ -2966,12 +3106,14 @@ fn test_donation_then_add_liquidity_sync_mitigates_mispricing() {
         donated_vault_a.clone(),
         donated_vault_b.clone(),
         AccountWithMetadataForTests::pool_lp_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         AccountWithMetadataForTests::user_holding_lp_init(),
         NonZero::new(1).unwrap(),
         100,
         50,
+        ATA_PROGRAM_ID,
     );
     let unsynced_pool_post = PoolDefinition::try_from(&post_unsynced[0].account().data).unwrap();
     let unsynced_delta_lp =
@@ -2996,12 +3138,14 @@ fn test_donation_then_add_liquidity_sync_mitigates_mispricing() {
         donated_vault_a_for_synced_add,
         donated_vault_b_for_synced_add,
         AccountWithMetadataForTests::pool_lp_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         AccountWithMetadataForTests::user_holding_lp_init(),
         NonZero::new(1).unwrap(),
         100,
         50,
+        ATA_PROGRAM_ID,
     );
     let synced_pool_post = PoolDefinition::try_from(&post_synced[0].account().data).unwrap();
     let synced_delta_lp = synced_pool_post.liquidity_pool_supply
@@ -3093,12 +3237,14 @@ fn add_liquidity_overflow_protection() {
         vault_a,
         vault_b,
         AccountWithMetadataForTests::pool_lp_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         AccountWithMetadataForTests::user_holding_lp_init(),
         NonZero::new(1).unwrap(),
         500,
         2, // max_amount_b=2 → reserve_a * 2 overflows
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -3177,12 +3323,14 @@ fn remove_liquidity_overflow_protection() {
         vault_a,
         vault_b,
         AccountWithMetadataForTests::pool_lp_init(),
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         user_lp,
         NonZero::new(2).unwrap(), // remove_amount=2 → reserve_a * 2 overflows
         1,
         1,
+        ATA_PROGRAM_ID,
     );
 }
 
@@ -3248,11 +3396,13 @@ fn swap_exact_input_overflow_protection() {
         pool,
         vault_a,
         vault_b,
+        AccountWithMetadataForTests::owner(),
         AccountWithMetadataForTests::user_holding_a(),
         AccountWithMetadataForTests::user_holding_b(),
         3,
         1,
         IdForTests::token_a_definition_id(),
+        ATA_PROGRAM_ID,
     );
 }
 

--- a/artifacts/amm-idl.json
+++ b/artifacts/amm-idl.json
@@ -1,3 +1,5 @@
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.53s
+     Running `target/debug/idl-gen amm/methods/guest/src/bin/amm.rs`
 {
   "version": "0.1.0",
   "name": "amm",
@@ -101,6 +103,12 @@
           "init": false
         },
         {
+          "name": "owner",
+          "writable": false,
+          "signer": false,
+          "init": false
+        },
+        {
           "name": "user_holding_a",
           "writable": false,
           "signer": false,
@@ -131,6 +139,10 @@
         {
           "name": "max_amount_to_add_token_b",
           "type": "u128"
+        },
+        {
+          "name": "ata_program_id",
+          "type": "program_id"
         }
       ]
     },
@@ -157,6 +169,12 @@
         },
         {
           "name": "pool_definition_lp",
+          "writable": false,
+          "signer": false,
+          "init": false
+        },
+        {
+          "name": "owner",
           "writable": false,
           "signer": false,
           "init": false
@@ -192,6 +210,10 @@
         {
           "name": "min_amount_to_remove_token_b",
           "type": "u128"
+        },
+        {
+          "name": "ata_program_id",
+          "type": "program_id"
         }
       ]
     },
@@ -212,6 +234,12 @@
         },
         {
           "name": "vault_b",
+          "writable": false,
+          "signer": false,
+          "init": false
+        },
+        {
+          "name": "owner",
           "writable": false,
           "signer": false,
           "init": false
@@ -241,6 +269,10 @@
         {
           "name": "token_definition_id_in",
           "type": "account_id"
+        },
+        {
+          "name": "ata_program_id",
+          "type": "program_id"
         }
       ]
     },
@@ -261,6 +293,12 @@
         },
         {
           "name": "vault_b",
+          "writable": false,
+          "signer": false,
+          "init": false
+        },
+        {
+          "name": "owner",
           "writable": false,
           "signer": false,
           "init": false
@@ -290,6 +328,10 @@
         {
           "name": "token_definition_id_in",
           "type": "account_id"
+        },
+        {
+          "name": "ata_program_id",
+          "type": "program_id"
         }
       ]
     },

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -12,3 +12,4 @@ ata_core = { workspace = true }
 token-methods = { path = "../token/methods" }
 amm-methods = { path = "../amm/methods" }
 ata-methods = { path = "../ata/methods" }
+malicious-ata-methods = { path = "malicious_ata_methods" }

--- a/integration_tests/malicious_ata_methods/Cargo.toml
+++ b/integration_tests/malicious_ata_methods/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "malicious-ata-methods"
+version = "0.1.0"
+edition = "2021"
+
+[build-dependencies]
+risc0-build = "=3.0.5"
+
+[dependencies]
+risc0-zkvm = { version = "=3.0.5", features = ["std"] }
+ata_core = { path = "../../ata/core" }
+
+[package.metadata.risc0]
+methods = ["guest"]

--- a/integration_tests/malicious_ata_methods/build.rs
+++ b/integration_tests/malicious_ata_methods/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    risc0_build::embed_methods();
+}

--- a/integration_tests/malicious_ata_methods/guest/Cargo.lock
+++ b/integration_tests/malicious_ata_methods/guest/Cargo.lock
@@ -30,36 +30,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "amm-methods"
-version = "0.1.0"
-dependencies = [
- "amm_core",
- "risc0-build",
- "risc0-zkvm",
-]
-
-[[package]]
-name = "amm_core"
-version = "0.1.0"
-dependencies = [
- "borsh",
- "nssa_core",
- "risc0-zkvm",
- "serde",
- "token_core",
-]
-
-[[package]]
-name = "amm_program"
-version = "0.1.0"
-dependencies = [
- "amm_core",
- "ata_core",
- "nssa_core",
- "token_core",
-]
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,7 +255,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -301,15 +271,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "ata-methods"
-version = "0.1.0"
-dependencies = [
- "ata_core",
- "risc0-build",
- "risc0-zkvm",
-]
-
-[[package]]
 name = "ata_core"
 version = "0.1.0"
 dependencies = [
@@ -317,15 +278,6 @@ dependencies = [
  "nssa_core",
  "risc0-zkvm",
  "serde",
-]
-
-[[package]]
-name = "ata_program"
-version = "0.1.0"
-dependencies = [
- "ata_core",
- "nssa_core",
- "token_core",
 ]
 
 [[package]]
@@ -387,9 +339,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "blake2"
@@ -545,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -597,15 +549,6 @@ dependencies = [
  "block-buffer 0.12.0",
  "crypto-common 0.2.1",
  "inout",
-]
-
-[[package]]
-name = "clock_core"
-version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc1#35d8df0d031315219f94d1546ceb862b0e5b208f"
-dependencies = [
- "borsh",
- "nssa_core",
 ]
 
 [[package]]
@@ -1045,9 +988,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
@@ -1254,9 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -1335,18 +1278,18 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.8"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8655f91cd07f2b9d0c24137bd650fe69617773435ee5ec83022377777ce65ef1"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1357,7 +1300,6 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1365,15 +1307,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1429,12 +1370,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1442,9 +1384,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1455,9 +1397,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1469,15 +1411,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1489,15 +1431,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1519,14 +1461,6 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "idl-gen"
-version = "0.1.0"
-dependencies = [
- "serde_json",
- "spel-framework-core",
-]
 
 [[package]]
 name = "idna"
@@ -1568,12 +1502,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1588,21 +1522,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "integration_tests"
-version = "0.1.0"
-dependencies = [
- "amm-methods",
- "amm_core",
- "ata-methods",
- "ata_core",
- "malicious-ata-methods",
- "nssa",
- "nssa_core",
- "token-methods",
- "token_core",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1610,9 +1529,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -1638,16 +1557,18 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1716,9 +1637,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libm"
@@ -1728,9 +1649,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
@@ -1743,9 +1664,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
@@ -1760,12 +1681,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "malicious-ata-methods"
+name = "malicious-ata-guest"
 version = "0.1.0"
 dependencies = [
  "ata_core",
- "risc0-build",
+ "borsh",
+ "nssa_core",
  "risc0-zkvm",
+ "serde",
+ "spel-framework",
 ]
 
 [[package]]
@@ -1812,7 +1736,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "block",
  "core-graphics-types",
  "foreign-types",
@@ -1823,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -1837,28 +1761,6 @@ name = "no_std_strings"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5b0c77c1b780822bc749a33e39aeb2c07584ab93332303babeabb645298a76e"
-
-[[package]]
-name = "nssa"
-version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc1#35d8df0d031315219f94d1546ceb862b0e5b208f"
-dependencies = [
- "anyhow",
- "borsh",
- "clock_core",
- "hex",
- "k256",
- "log",
- "nssa_core",
- "rand 0.8.5",
- "risc0-binfmt",
- "risc0-build",
- "risc0-zkvm",
- "serde",
- "serde_with",
- "sha2",
- "thiserror 2.0.18",
-]
 
 [[package]]
 name = "nssa_core"
@@ -1898,16 +1800,16 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -2009,12 +1911,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2049,9 +1945,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2087,7 +1983,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.5+spec-1.1.0",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -2113,13 +2009,13 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "unarray",
@@ -2177,7 +2073,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2226,20 +2122,19 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
- "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2431,7 +2326,7 @@ dependencies = [
  "elf",
  "lazy_static",
  "postcard",
- "rand 0.9.2",
+ "rand 0.9.4",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "ruint",
@@ -2664,14 +2559,14 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.17.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
+checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
 dependencies = [
  "borsh",
  "proptest",
- "rand 0.8.5",
- "rand 0.9.2",
+ "rand 0.8.6",
+ "rand 0.9.4",
  "ruint-macro",
  "serde_core",
  "valuable",
@@ -2686,9 +2581,9 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -2705,7 +2600,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2714,9 +2609,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "once_cell",
  "ring",
@@ -2738,9 +2633,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2819,9 +2714,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -2901,7 +2796,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -2982,6 +2877,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "spel-framework"
+version = "0.2.0"
+source = "git+https://github.com/logos-co/spel.git?tag=v0.2.0-rc.2#9005e9fbbd78b0530412f9987273f753ed32eb2d"
+dependencies = [
+ "borsh",
+ "nssa_core",
+ "spel-framework-core",
+ "spel-framework-macros",
+]
+
+[[package]]
 name = "spel-framework-core"
 version = "0.2.0"
 source = "git+https://github.com/logos-co/spel.git?tag=v0.2.0-rc.2#9005e9fbbd78b0530412f9987273f753ed32eb2d"
@@ -2991,8 +2897,18 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "syn 2.0.117",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "spel-framework-macros"
+version = "0.2.0"
+source = "git+https://github.com/logos-co/spel.git?tag=v0.2.0-rc.2#9005e9fbbd78b0530412f9987273f753ed32eb2d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sha2",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3188,9 +3104,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3212,36 +3128,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "token-methods"
-version = "0.1.0"
-dependencies = [
- "risc0-build",
- "risc0-zkvm",
- "token_core",
-]
-
-[[package]]
-name = "token_core"
-version = "0.1.0"
-dependencies = [
- "borsh",
- "nssa_core",
- "serde",
-]
-
-[[package]]
-name = "token_program"
-version = "0.1.0"
-dependencies = [
- "nssa_core",
- "token_core",
-]
-
-[[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -3297,9 +3187,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.1+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -3310,7 +3200,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned",
  "toml_datetime 0.6.11",
@@ -3320,23 +3210,23 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.5+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap 2.13.0",
- "toml_datetime 1.0.1+spec-1.1.0",
+ "indexmap 2.14.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.0",
+ "winnow 1.0.2",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.10+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.0",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -3366,7 +3256,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -3440,9 +3330,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unarray"
@@ -3515,11 +3405,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -3528,14 +3418,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3546,23 +3436,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3570,9 +3456,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3583,9 +3469,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -3607,7 +3493,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -3631,17 +3517,17 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3659,9 +3545,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3892,9 +3778,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
@@ -3907,6 +3793,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -3927,7 +3819,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -3957,8 +3849,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "bitflags 2.11.1",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -3977,7 +3869,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -3989,9 +3881,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yaml-rust2"
@@ -4006,9 +3898,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -4017,9 +3909,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4029,18 +3921,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4049,18 +3941,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4090,9 +3982,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4101,9 +3993,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4112,9 +4004,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/integration_tests/malicious_ata_methods/guest/Cargo.toml
+++ b/integration_tests/malicious_ata_methods/guest/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "malicious-ata-guest"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+
+[[bin]]
+name = "malicious_ata"
+path = "src/bin/malicious_ata.rs"
+
+[dependencies]
+spel-framework = { git = "https://github.com/logos-co/spel.git", tag = "v0.2.0-rc.2", package = "spel-framework" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1" }
+risc0-zkvm = { version = "=3.0.5", default-features = false }
+ata_core = { path = "../../../ata/core" }
+serde = { version = "1.0", features = ["derive"] }
+borsh = "1.5"

--- a/integration_tests/malicious_ata_methods/guest/src/bin/malicious_ata.rs
+++ b/integration_tests/malicious_ata_methods/guest/src/bin/malicious_ata.rs
@@ -1,0 +1,78 @@
+#![no_main]
+
+use nssa_core::{
+    account::AccountWithMetadata,
+    program::{AccountPostState, ProgramId},
+};
+use spel_framework::prelude::*;
+
+risc0_zkvm::guest::entry!(main);
+
+fn unchanged_post_state(account: AccountWithMetadata) -> AccountPostState {
+    AccountPostState::new(account.account)
+}
+
+#[lez_program(instruction = "ata_core::Instruction")]
+mod malicious_ata {
+    #[allow(unused_imports)]
+    use super::*;
+
+    /// Intentionally malicious test helper. It acknowledges ATA creation without creating
+    /// anything, proving callers must not trust a caller-supplied ATA program ID.
+    #[instruction]
+    pub fn create(
+        owner: AccountWithMetadata,
+        token_definition: AccountWithMetadata,
+        ata_account: AccountWithMetadata,
+        ata_program_id: ProgramId,
+    ) -> SpelResult {
+        let _ = ata_program_id;
+        assert!(owner.is_authorized, "Owner authorization is missing");
+
+        Ok(SpelOutput::states_only(vec![
+            unchanged_post_state(owner),
+            unchanged_post_state(token_definition),
+            unchanged_post_state(ata_account),
+        ]))
+    }
+
+    /// Intentionally malicious test helper. It returns success without debiting the sender
+    /// or crediting the recipient.
+    #[instruction]
+    pub fn transfer(
+        owner: AccountWithMetadata,
+        sender_ata: AccountWithMetadata,
+        recipient: AccountWithMetadata,
+        ata_program_id: ProgramId,
+        amount: u128,
+    ) -> SpelResult {
+        let _ = (ata_program_id, amount);
+        assert!(owner.is_authorized, "Owner authorization is missing");
+
+        Ok(SpelOutput::states_only(vec![
+            unchanged_post_state(owner),
+            unchanged_post_state(sender_ata),
+            unchanged_post_state(recipient),
+        ]))
+    }
+
+    /// Intentionally malicious test helper. It returns success without burning the LP position
+    /// or decreasing the LP definition supply.
+    #[instruction]
+    pub fn burn(
+        owner: AccountWithMetadata,
+        holder_ata: AccountWithMetadata,
+        token_definition: AccountWithMetadata,
+        ata_program_id: ProgramId,
+        amount: u128,
+    ) -> SpelResult {
+        let _ = (ata_program_id, amount);
+        assert!(owner.is_authorized, "Owner authorization is missing");
+
+        Ok(SpelOutput::states_only(vec![
+            unchanged_post_state(owner),
+            unchanged_post_state(holder_ata),
+            unchanged_post_state(token_definition),
+        ]))
+    }
+}

--- a/integration_tests/malicious_ata_methods/src/lib.rs
+++ b/integration_tests/malicious_ata_methods/src/lib.rs
@@ -1,0 +1,1 @@
+include!(concat!(env!("OUT_DIR"), "/methods.rs"));

--- a/integration_tests/tests/amm.rs
+++ b/integration_tests/tests/amm.rs
@@ -38,6 +38,10 @@ impl Ids {
         amm_methods::AMM_ID
     }
 
+    fn ata_program() -> nssa_core::program::ProgramId {
+        ata_methods::ATA_ID
+    }
+
     fn token_a_definition() -> AccountId {
         AccountId::new([3; 32])
     }
@@ -1018,6 +1022,7 @@ fn execute_swap_a_to_b(state: &mut V03State, swap_amount_in: u128, min_amount_ou
         swap_amount_in,
         min_amount_out,
         token_definition_id_in: Ids::token_a_definition(),
+        ata_program_id: Ids::ata_program(),
     };
 
     let message = public_transaction::Message::try_new(
@@ -1045,6 +1050,7 @@ fn execute_swap_b_to_a(state: &mut V03State, swap_amount_in: u128, min_amount_ou
         swap_amount_in,
         min_amount_out,
         token_definition_id_in: Ids::token_b_definition(),
+        ata_program_id: Ids::ata_program(),
     };
 
     let message = public_transaction::Message::try_new(
@@ -1077,6 +1083,7 @@ fn execute_add_liquidity(
         min_amount_liquidity,
         max_amount_to_add_token_a,
         max_amount_to_add_token_b,
+        ata_program_id: Ids::ata_program(),
     };
 
     let message = public_transaction::Message::try_new(
@@ -1115,6 +1122,7 @@ fn execute_remove_liquidity(
         remove_liquidity_amount,
         min_amount_to_remove_token_a,
         min_amount_to_remove_token_b,
+        ata_program_id: Ids::ata_program(),
     };
 
     let message = public_transaction::Message::try_new(
@@ -1178,6 +1186,7 @@ fn amm_remove_liquidity() {
         remove_liquidity_amount: Balances::remove_lp(),
         min_amount_to_remove_token_a: Balances::remove_min_a(),
         min_amount_to_remove_token_b: Balances::remove_min_b(),
+        ata_program_id: Ids::ata_program(),
     };
 
     let message = public_transaction::Message::try_new(
@@ -1240,6 +1249,7 @@ fn amm_remove_liquidity_insufficient_user_lp_fails() {
         remove_liquidity_amount: Balances::remove_lp(),
         min_amount_to_remove_token_a: Balances::remove_min_a(),
         min_amount_to_remove_token_b: Balances::remove_min_b(),
+        ata_program_id: Ids::ata_program(),
     };
 
     let message = public_transaction::Message::try_new(
@@ -1464,6 +1474,7 @@ fn amm_add_liquidity() {
         min_amount_liquidity: Balances::add_min_lp(),
         max_amount_to_add_token_a: Balances::add_max_a(),
         max_amount_to_add_token_b: Balances::add_max_b(),
+        ata_program_id: Ids::ata_program(),
     };
 
     let message = public_transaction::Message::try_new(
@@ -1526,6 +1537,7 @@ fn amm_swap_b_to_a() {
         swap_amount_in: Balances::swap_amount_in(),
         min_amount_out: Balances::swap_min_out(),
         token_definition_id_in: Ids::token_b_definition(),
+        ata_program_id: Ids::ata_program(),
     };
 
     let message = public_transaction::Message::try_new(
@@ -1577,6 +1589,7 @@ fn amm_swap_a_to_b() {
         swap_amount_in: Balances::swap_amount_in(),
         min_amount_out: Balances::swap_min_out(),
         token_definition_id_in: Ids::token_a_definition(),
+        ata_program_id: Ids::ata_program(),
     };
 
     let message = public_transaction::Message::try_new(

--- a/integration_tests/tests/amm.rs
+++ b/integration_tests/tests/amm.rs
@@ -1,13 +1,17 @@
 use amm_core::{
-    PoolDefinition, FEE_TIER_BPS_1, FEE_TIER_BPS_100, FEE_TIER_BPS_30, FEE_TIER_BPS_5,
-    MINIMUM_LIQUIDITY,
+    PoolDefinition, FEE_BPS_DENOMINATOR, FEE_TIER_BPS_1, FEE_TIER_BPS_100, FEE_TIER_BPS_30,
+    FEE_TIER_BPS_5, MINIMUM_LIQUIDITY,
 };
+use ata_core::{compute_ata_seed, get_associated_token_account_id};
 use nssa::{
     error::NssaError,
     program_deployment_transaction::{self, ProgramDeploymentTransaction},
     public_transaction, PrivateKey, PublicKey, PublicTransaction, V03State,
 };
-use nssa_core::account::{Account, AccountId, Data, Nonce};
+use nssa_core::{
+    account::{Account, AccountId, Data, Nonce},
+    program::ProgramId,
+};
 use token_core::{TokenDefinition, TokenHolding};
 
 struct Keys;
@@ -16,6 +20,10 @@ struct Balances;
 struct Accounts;
 
 impl Keys {
+    fn owner() -> PrivateKey {
+        PrivateKey::try_new([30; 32]).expect("valid private key")
+    }
+
     fn user_a() -> PrivateKey {
         PrivateKey::try_new([31; 32]).expect("valid private key")
     }
@@ -40,6 +48,10 @@ impl Ids {
 
     fn ata_program() -> nssa_core::program::ProgramId {
         ata_methods::ATA_ID
+    }
+
+    fn malicious_ata_program() -> ProgramId {
+        malicious_ata_methods::MALICIOUS_ATA_ID
     }
 
     fn token_a_definition() -> AccountId {
@@ -92,6 +104,31 @@ impl Ids {
 
     fn user_lp() -> AccountId {
         AccountId::from(&PublicKey::new_from_private_key(&Keys::user_lp()))
+    }
+
+    fn owner() -> AccountId {
+        AccountId::from(&PublicKey::new_from_private_key(&Keys::owner()))
+    }
+
+    fn owner_token_a_ata() -> AccountId {
+        get_associated_token_account_id(
+            &Self::ata_program(),
+            &compute_ata_seed(Self::owner(), Self::token_a_definition()),
+        )
+    }
+
+    fn owner_token_b_ata() -> AccountId {
+        get_associated_token_account_id(
+            &Self::ata_program(),
+            &compute_ata_seed(Self::owner(), Self::token_b_definition()),
+        )
+    }
+
+    fn owner_token_lp_ata() -> AccountId {
+        get_associated_token_account_id(
+            &Self::ata_program(),
+            &compute_ata_seed(Self::owner(), Self::token_lp_definition()),
+        )
     }
 }
 
@@ -282,6 +319,15 @@ impl Balances {
 }
 
 impl Accounts {
+    fn owner() -> Account {
+        Account {
+            program_owner: ProgramId::default(),
+            balance: 0_u128,
+            data: Data::default(),
+            nonce: Nonce(0),
+        }
+    }
+
     fn user_a_holding() -> Account {
         Account {
             program_owner: Ids::token_program(),
@@ -407,6 +453,42 @@ impl Accounts {
             data: Data::from(&TokenHolding::Fungible {
                 definition_id: Ids::token_lp_definition(),
                 balance,
+            }),
+            nonce: Nonce(0),
+        }
+    }
+
+    fn owner_token_a_ata() -> Account {
+        Account {
+            program_owner: Ids::token_program(),
+            balance: 0_u128,
+            data: Data::from(&TokenHolding::Fungible {
+                definition_id: Ids::token_a_definition(),
+                balance: Balances::user_a_init(),
+            }),
+            nonce: Nonce(0),
+        }
+    }
+
+    fn owner_token_b_ata() -> Account {
+        Account {
+            program_owner: Ids::token_program(),
+            balance: 0_u128,
+            data: Data::from(&TokenHolding::Fungible {
+                definition_id: Ids::token_b_definition(),
+                balance: Balances::user_b_init(),
+            }),
+            nonce: Nonce(0),
+        }
+    }
+
+    fn owner_token_lp_ata() -> Account {
+        Account {
+            program_owner: Ids::token_program(),
+            balance: 0_u128,
+            data: Data::from(&TokenHolding::Fungible {
+                definition_id: Ids::token_lp_definition(),
+                balance: Balances::user_lp_init(),
             }),
             nonce: Nonce(0),
         }
@@ -893,21 +975,25 @@ impl Accounts {
     }
 }
 
-fn deploy_programs(state: &mut V03State) {
-    let token_message =
-        program_deployment_transaction::Message::new(token_methods::TOKEN_ELF.to_vec());
+fn deploy_program(state: &mut V03State, elf: &[u8], name: &str) {
+    let message = program_deployment_transaction::Message::new(elf.to_vec());
     state
-        .transition_from_program_deployment_transaction(&ProgramDeploymentTransaction::new(
-            token_message,
-        ))
-        .expect("token program deployment must succeed");
+        .transition_from_program_deployment_transaction(&ProgramDeploymentTransaction::new(message))
+        .unwrap_or_else(|_| panic!("{name} program deployment must succeed"));
+}
 
-    let amm_message = program_deployment_transaction::Message::new(amm_methods::AMM_ELF.to_vec());
-    state
-        .transition_from_program_deployment_transaction(&ProgramDeploymentTransaction::new(
-            amm_message,
-        ))
-        .expect("amm program deployment must succeed");
+fn deploy_programs(state: &mut V03State) {
+    deploy_program(state, token_methods::TOKEN_ELF, "token");
+    deploy_program(state, amm_methods::AMM_ELF, "amm");
+}
+
+fn deploy_programs_with_malicious_ata(state: &mut V03State) {
+    deploy_programs(state);
+    deploy_program(
+        state,
+        malicious_ata_methods::MALICIOUS_ATA_ELF,
+        "malicious ata",
+    );
 }
 
 fn state_for_amm_tests() -> V03State {
@@ -950,8 +1036,51 @@ fn state_for_amm_tests_with_new_def() -> V03State {
     state
 }
 
+fn state_for_malicious_ata_attack() -> V03State {
+    let mut state = V03State::new_with_genesis_accounts(&[], &[], 0);
+    deploy_programs_with_malicious_ata(&mut state);
+    state.force_insert_account(Ids::pool_definition(), Accounts::pool_definition_init());
+    state.force_insert_account(
+        Ids::token_a_definition(),
+        Accounts::token_a_definition_account(),
+    );
+    state.force_insert_account(
+        Ids::token_b_definition(),
+        Accounts::token_b_definition_account(),
+    );
+    state.force_insert_account(
+        Ids::token_lp_definition(),
+        Accounts::token_lp_definition_account(),
+    );
+    state.force_insert_account(Ids::owner(), Accounts::owner());
+    state.force_insert_account(Ids::owner_token_a_ata(), Accounts::owner_token_a_ata());
+    state.force_insert_account(Ids::owner_token_b_ata(), Accounts::owner_token_b_ata());
+    state.force_insert_account(Ids::owner_token_lp_ata(), Accounts::owner_token_lp_ata());
+    state.force_insert_account(Ids::vault_a(), Accounts::vault_a_init());
+    state.force_insert_account(Ids::vault_b(), Accounts::vault_b_init());
+    state
+}
+
 fn current_nonce(state: &V03State, account_id: AccountId) -> Nonce {
     state.get_account_by_id(account_id).nonce
+}
+
+fn try_execute_amm_as_owner(
+    state: &mut V03State,
+    instruction: amm_core::Instruction,
+    accounts: Vec<AccountId>,
+) -> Result<(), NssaError> {
+    let message = public_transaction::Message::try_new(
+        Ids::amm_program(),
+        accounts,
+        vec![current_nonce(state, Ids::owner())],
+        instruction,
+    )
+    .unwrap();
+
+    let witness_set = public_transaction::WitnessSet::for_message(&message, &[&Keys::owner()]);
+    let tx = PublicTransaction::new(message, witness_set);
+    state.transition_from_public_transaction(&tx, 0, 0)
 }
 
 fn state_for_amm_tests_with_precreated_user_lp_for_new_def() -> V03State {
@@ -1176,6 +1305,290 @@ fn fungible_total_supply(account: &Account) -> u128 {
     };
 
     total_supply
+}
+
+fn exact_output_required_amount_in(
+    reserve_in: u128,
+    reserve_out: u128,
+    exact_amount_out: u128,
+    fee_bps: u128,
+) -> u128 {
+    let effective_in_min = reserve_in
+        .checked_mul(exact_amount_out)
+        .expect("reserve_in * exact_amount_out overflows")
+        .div_ceil(
+            reserve_out
+                .checked_sub(exact_amount_out)
+                .expect("exact_amount_out must stay below reserve_out"),
+        );
+    let fee_multiplier = FEE_BPS_DENOMINATOR
+        .checked_sub(fee_bps)
+        .expect("fee_bps exceeds denominator");
+
+    effective_in_min
+        .checked_mul(FEE_BPS_DENOMINATOR)
+        .expect("effective_in_min * denominator overflows")
+        .div_ceil(fee_multiplier)
+}
+
+fn add_liquidity_malicious_ata_attack_witness() -> Option<&'static str> {
+    let mut state = state_for_malicious_ata_attack();
+    let instruction = amm_core::Instruction::AddLiquidity {
+        min_amount_liquidity: Balances::add_min_lp(),
+        max_amount_to_add_token_a: Balances::add_max_a(),
+        max_amount_to_add_token_b: Balances::add_max_b(),
+        ata_program_id: Ids::malicious_ata_program(),
+    };
+
+    if try_execute_amm_as_owner(
+        &mut state,
+        instruction,
+        vec![
+            Ids::pool_definition(),
+            Ids::vault_a(),
+            Ids::vault_b(),
+            Ids::token_lp_definition(),
+            Ids::owner(),
+            Ids::owner_token_a_ata(),
+            Ids::owner_token_b_ata(),
+            Ids::owner_token_lp_ata(),
+        ],
+    )
+    .is_err()
+    {
+        return None;
+    }
+
+    let pool = pool_definition(&state.get_account_by_id(Ids::pool_definition()));
+    assert_eq!(pool.liquidity_pool_supply, Balances::token_lp_supply_add());
+    assert_eq!(pool.reserve_a, Balances::vault_a_add());
+    assert_eq!(pool.reserve_b, Balances::vault_b_add());
+    assert_eq!(
+        fungible_total_supply(&state.get_account_by_id(Ids::token_lp_definition())),
+        Balances::token_lp_supply_add()
+    );
+    assert_eq!(
+        fungible_balance(&state.get_account_by_id(Ids::owner_token_lp_ata())),
+        Balances::user_lp_add()
+    );
+    assert_eq!(
+        fungible_balance(&state.get_account_by_id(Ids::owner_token_a_ata())),
+        Balances::user_a_init()
+    );
+    assert_eq!(
+        fungible_balance(&state.get_account_by_id(Ids::owner_token_b_ata())),
+        Balances::user_b_init()
+    );
+    assert_eq!(
+        fungible_balance(&state.get_account_by_id(Ids::vault_a())),
+        Balances::vault_a_init()
+    );
+    assert_eq!(
+        fungible_balance(&state.get_account_by_id(Ids::vault_b())),
+        Balances::vault_b_init()
+    );
+
+    Some(
+        "add_liquidity: LP supply and owner LP balance increase while both deposit legs leave balances unchanged",
+    )
+}
+
+fn remove_liquidity_malicious_ata_attack_witness() -> Option<&'static str> {
+    let mut state = state_for_malicious_ata_attack();
+    let instruction = amm_core::Instruction::RemoveLiquidity {
+        remove_liquidity_amount: Balances::remove_lp(),
+        min_amount_to_remove_token_a: Balances::remove_min_a(),
+        min_amount_to_remove_token_b: Balances::remove_min_b(),
+        ata_program_id: Ids::malicious_ata_program(),
+    };
+
+    if try_execute_amm_as_owner(
+        &mut state,
+        instruction,
+        vec![
+            Ids::pool_definition(),
+            Ids::vault_a(),
+            Ids::vault_b(),
+            Ids::token_lp_definition(),
+            Ids::owner(),
+            Ids::owner_token_a_ata(),
+            Ids::owner_token_b_ata(),
+            Ids::owner_token_lp_ata(),
+        ],
+    )
+    .is_err()
+    {
+        return None;
+    }
+
+    let pool = pool_definition(&state.get_account_by_id(Ids::pool_definition()));
+    assert_eq!(
+        pool.liquidity_pool_supply,
+        Balances::token_lp_supply_remove()
+    );
+    assert_eq!(pool.reserve_a, Balances::vault_a_remove());
+    assert_eq!(pool.reserve_b, Balances::vault_b_remove());
+    assert_eq!(
+        fungible_balance(&state.get_account_by_id(Ids::owner_token_a_ata())),
+        Balances::user_a_remove()
+    );
+    assert_eq!(
+        fungible_balance(&state.get_account_by_id(Ids::owner_token_b_ata())),
+        Balances::user_b_remove()
+    );
+    assert_eq!(
+        fungible_balance(&state.get_account_by_id(Ids::vault_a())),
+        Balances::vault_a_remove()
+    );
+    assert_eq!(
+        fungible_balance(&state.get_account_by_id(Ids::vault_b())),
+        Balances::vault_b_remove()
+    );
+    assert_eq!(
+        fungible_balance(&state.get_account_by_id(Ids::owner_token_lp_ata())),
+        Balances::user_lp_init()
+    );
+    assert_eq!(
+        fungible_total_supply(&state.get_account_by_id(Ids::token_lp_definition())),
+        Balances::token_lp_supply()
+    );
+
+    Some(
+        "remove_liquidity: owner receives vault tokens while LP balance and LP definition supply stay unchanged",
+    )
+}
+
+fn swap_exact_input_malicious_ata_attack_witness() -> Option<&'static str> {
+    let mut state = state_for_malicious_ata_attack();
+    let instruction = amm_core::Instruction::SwapExactInput {
+        swap_amount_in: Balances::swap_amount_in(),
+        min_amount_out: Balances::swap_min_out(),
+        token_definition_id_in: Ids::token_a_definition(),
+        ata_program_id: Ids::malicious_ata_program(),
+    };
+
+    if try_execute_amm_as_owner(
+        &mut state,
+        instruction,
+        vec![
+            Ids::pool_definition(),
+            Ids::vault_a(),
+            Ids::vault_b(),
+            Ids::owner(),
+            Ids::owner_token_a_ata(),
+            Ids::owner_token_b_ata(),
+        ],
+    )
+    .is_err()
+    {
+        return None;
+    }
+
+    let pool = pool_definition(&state.get_account_by_id(Ids::pool_definition()));
+    assert_eq!(pool.reserve_a, Balances::reserve_a_swap_2());
+    assert_eq!(pool.reserve_b, Balances::reserve_b_swap_2());
+    assert_eq!(
+        fungible_balance(&state.get_account_by_id(Ids::owner_token_a_ata())),
+        Balances::user_a_init()
+    );
+    assert_eq!(
+        fungible_balance(&state.get_account_by_id(Ids::owner_token_b_ata())),
+        Balances::user_b_swap_2()
+    );
+    assert_eq!(
+        fungible_balance(&state.get_account_by_id(Ids::vault_a())),
+        Balances::vault_a_init()
+    );
+    assert_eq!(
+        fungible_balance(&state.get_account_by_id(Ids::vault_b())),
+        Balances::vault_b_swap_2()
+    );
+
+    Some(
+        "swap_exact_input: owner receives output while the input balance and deposit vault stay unchanged",
+    )
+}
+
+fn swap_exact_output_malicious_ata_attack_witness() -> Option<&'static str> {
+    const EXACT_AMOUNT_OUT: u128 = 500;
+    const MAX_AMOUNT_IN: u128 = 2_000;
+
+    let mut state = state_for_malicious_ata_attack();
+    let instruction = amm_core::Instruction::SwapExactOutput {
+        exact_amount_out: EXACT_AMOUNT_OUT,
+        max_amount_in: MAX_AMOUNT_IN,
+        token_definition_id_in: Ids::token_a_definition(),
+        ata_program_id: Ids::malicious_ata_program(),
+    };
+
+    if try_execute_amm_as_owner(
+        &mut state,
+        instruction,
+        vec![
+            Ids::pool_definition(),
+            Ids::vault_a(),
+            Ids::vault_b(),
+            Ids::owner(),
+            Ids::owner_token_a_ata(),
+            Ids::owner_token_b_ata(),
+        ],
+    )
+    .is_err()
+    {
+        return None;
+    }
+
+    let required_amount_in = exact_output_required_amount_in(
+        Balances::vault_a_init(),
+        Balances::vault_b_init(),
+        EXACT_AMOUNT_OUT,
+        Balances::fee_tier(),
+    );
+    let pool = pool_definition(&state.get_account_by_id(Ids::pool_definition()));
+    assert_eq!(
+        pool.reserve_a,
+        Balances::vault_a_init() + required_amount_in
+    );
+    assert_eq!(pool.reserve_b, Balances::vault_b_init() - EXACT_AMOUNT_OUT);
+    assert_eq!(
+        fungible_balance(&state.get_account_by_id(Ids::owner_token_a_ata())),
+        Balances::user_a_init()
+    );
+    assert_eq!(
+        fungible_balance(&state.get_account_by_id(Ids::owner_token_b_ata())),
+        Balances::user_b_init() + EXACT_AMOUNT_OUT
+    );
+    assert_eq!(
+        fungible_balance(&state.get_account_by_id(Ids::vault_a())),
+        Balances::vault_a_init()
+    );
+    assert_eq!(
+        fungible_balance(&state.get_account_by_id(Ids::vault_b())),
+        Balances::vault_b_init() - EXACT_AMOUNT_OUT
+    );
+
+    Some(
+        "swap_exact_output: owner receives exact output while the required input balance and deposit vault stay unchanged",
+    )
+}
+
+#[test]
+fn amm_rejects_malicious_ata_program_for_all_value_paths() {
+    let accepted_attacks = [
+        add_liquidity_malicious_ata_attack_witness(),
+        remove_liquidity_malicious_ata_attack_witness(),
+        swap_exact_input_malicious_ata_attack_witness(),
+        swap_exact_output_malicious_ata_attack_witness(),
+    ]
+    .into_iter()
+    .flatten()
+    .collect::<Vec<_>>();
+
+    assert!(
+        accepted_attacks.is_empty(),
+        "AMM accepted a malicious ATA program for value paths: {}",
+        accepted_attacks.join("; ")
+    );
 }
 
 #[test]


### PR DESCRIPTION
Add `owner` and `ata_program_id` parameters to `add_liquidity`, `remove_liquidity`, `swap_exact_input`, and `swap_exact_output`. User deposit-side transfers now emit `ATA::Transfer` chained calls instead of `Token::Transfer` directly, and LP burns emit `ATA::Burn` instead of `Token::Burn`. Vault withdrawal chained calls are unchanged.

- Add `ata_program_id` field to `AddLiquidity`, `RemoveLiquidity`, `SwapExactInput`, and `SwapExactOutput` instruction variants in `amm_core`
- Add `ata_core` dependency to `amm_program` and guest crates
- Update guest binary, unit tests, and integration tests to supply the new `owner` account and `ata_program_id` at every call site
- Regenerate `artifacts/amm-idl.json`

Closes #11