### PR TITLE
chore: fix RISC-V guest build on macOS 26

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[env]
+# Prevent cc-rs from injecting macOS-specific flags (e.g. -arch arm64, -mmacosx-version-min)
+# into the RISC-V cross-compiler when building C dependencies (e.g. ring) for the guest target.
+# Without this, builds fail on macOS 26+ with the risc0 C++ toolchain.
+CFLAGS_riscv32im_risc0_zkvm_elf = "-march=rv32im -nostdlib"


### PR DESCRIPTION
Add .cargo/config.toml setting CFLAGS_riscv32im_risc0_zkvm_elf to "-march=rv32im -nostdlib". This prevents cc-rs from injecting macOS-specific flags (-arch arm64, -mmacosx-version-min) into the riscv32-unknown-elf-gcc cross-compiler when building C dependencies (e.g. ring) for the guest target, which causes build failures on macOS 26 Tahoe.