### PR TITLE
chore(amm): add Logos Basecamp support

### DIFF
--- a/apps/amm/.gitignore
+++ b/apps/amm/.gitignore
@@ -1,0 +1,3 @@
+result
+result-*
+modules/

--- a/apps/amm/README.md
+++ b/apps/amm/README.md
@@ -40,7 +40,15 @@ This project requires Nix with experimental features enabled. If you haven't alr
 mkdir -p ~/.config/nix && echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
 ```
 
-## Running the UI
+Install the Logos package manager CLI globally (one-time):
+
+```bash
+nix profile install 'github:logos-co/logos-package-manager#cli'
+```
+
+This makes `lgpm` available as a global command.
+
+## Running the UI standalone
 
 Start the UI with:
 
@@ -48,7 +56,74 @@ Start the UI with:
 nix run .
 ```
 
-This builds and runs the application in development mode.
+This builds and runs the application in development mode. The Logos bridge is unavailable in standalone mode, but the UI layout and mock data are fully functional.
+
+## Running inside Logos Basecamp
+
+This app is a UI plugin that depends on the **core wallet module**
+`logos_execution_zone` (see the Wallet / chain integration section above). Both
+have to be installed into Basecamp — the UI plugin alone will show the AMM tab
+but fail to open it with `Failed to load core dependencies for amm_ui`.
+
+### 1. Build the LGX packages
+
+```bash
+# The AMM UI plugin — development variant (requires nix store at runtime)
+nix build '.#lgx' --out-link result-lgx
+
+# Portable variant (self-contained, works without nix)
+nix build '.#lgx-portable' --out-link result-lgx-portable
+
+# The core wallet module it depends on. Use the same rev this app pins as the
+# `logos_execution_zone` input in flake.nix so the ImageID/ABI match.
+nix build 'github:logos-blockchain/logos-execution-zone-module?rev=d2e9400ac06c3cdbfc2405b4f153fff9841a453c#lgx' \
+  --out-link result-core
+```
+
+### 2. Install into Basecamp
+
+```bash
+# Launch Basecamp once to initialise its data directory, then quit (see below)
+
+# Set the data directory path
+# macOS:
+BASECAMP_DIR="$HOME/Library/Application Support/Logos/LogosBasecampDev"
+# Linux:
+# BASECAMP_DIR="$HOME/.local/share/Logos/LogosBasecampDev"
+
+# Install the core wallet module first (into the modules dir), then the UI plugin
+lgpm --modules-dir "$BASECAMP_DIR/modules" \
+  install --file result-core/*.lgx
+lgpm --ui-plugins-dir "$BASECAMP_DIR/plugins" \
+  install --file result-lgx/*.lgx
+```
+
+> **Note:** Use matching variants throughout — dev with dev, portable with portable. Mixing variants causes loading failures. The portable build uses the `LogosBasecamp` data directory instead of `LogosBasecampDev`.
+
+### 3. Launch Basecamp
+
+```bash
+nix build 'github:logos-co/logos-basecamp' --accept-flake-config -o ~/.basecamp-result
+~/.basecamp-result/bin/LogosBasecamp
+```
+
+The AMM UI appears as a new tab in the Basecamp sidebar.
+
+> **Note:** `nix run 'github:logos-co/logos-basecamp'` currently fails with
+> `unable to execute ... No such file or directory` — the flake's default app
+> is named `logos-basecamp` but the packaged binary is `LogosBasecamp`. Build
+> the package and run the `bin/LogosBasecamp` wrapper directly, as above.
+
+### Installing via the Basecamp UI
+
+Alternatively, use the built-in package manager. Install both packages — the
+core module from `result-core/` and the UI plugin from `result-lgx/`:
+
+1. Launch Basecamp
+2. Open Package Manager
+3. Select "Install from file"
+4. Choose the core module `.lgx` from `result-core/`, then the UI plugin `.lgx`
+   from `result-lgx/`
 
 ## Updating Dependencies
 
@@ -56,4 +131,19 @@ To update the pinned versions of dependencies in `flake.lock`:
 
 ```bash
 nix flake update
+```
+
+## Troubleshooting
+
+**Stale QML cache after rebuild:**
+```bash
+QML_DISABLE_DISK_CACHE=1 ~/.basecamp-result/bin/LogosBasecamp
+```
+
+**Reset Basecamp data directory:**
+```bash
+# macOS
+rm -rf ~/Library/Application\ Support/Logos/LogosBasecampDev
+# Linux
+rm -rf ~/.local/share/Logos/LogosBasecampDev
 ```


### PR DESCRIPTION
Provides the necessary instructions to run the AMM app inside Logos Basecamp.

Closes #29