### PR TITLE
chore(amm): validate fee tier in `sync_reserves`

### DIFF
--- a/amm/src/sync.rs
+++ b/amm/src/sync.rs
@@ -1,4 +1,6 @@
-use amm_core::{read_vault_fungible_balances, PoolDefinition, MINIMUM_LIQUIDITY};
+use amm_core::{
+    assert_supported_fee_tier, read_vault_fungible_balances, PoolDefinition, MINIMUM_LIQUIDITY,
+};
 use nssa_core::{
     account::{AccountWithMetadata, Data},
     program::{AccountPostState, ChainedCall},
@@ -11,6 +13,7 @@ pub fn sync_reserves(
 ) -> (Vec<AccountPostState>, Vec<ChainedCall>) {
     let pool_def_data = PoolDefinition::try_from(&pool.account.data)
         .expect("Sync reserves: AMM Program expects a valid Pool Definition Account");
+    assert_supported_fee_tier(pool_def_data.fees);
 
     assert!(
         pool_def_data.liquidity_pool_supply >= MINIMUM_LIQUIDITY,

--- a/amm/src/tests.rs
+++ b/amm/src/tests.rs
@@ -2983,6 +2983,21 @@ fn test_sync_reserves_rejects_pool_below_minimum_liquidity() {
     );
 }
 
+#[should_panic(expected = "Fee tier must be one of 1, 5, 30, or 100 basis points")]
+#[test]
+fn test_sync_reserves_rejects_unsupported_fee_tier() {
+    let mut pool = AccountWithMetadataForTests::pool_definition_init();
+    let mut pool_def = PoolDefinition::try_from(&pool.account.data).unwrap();
+    pool_def.fees = 2;
+    pool.account.data = Data::from(&pool_def);
+
+    let _ = sync_reserves(
+        pool,
+        AccountWithMetadataForTests::vault_a_init(),
+        AccountWithMetadataForTests::vault_b_init(),
+    );
+}
+
 #[test]
 fn test_donation_then_add_liquidity_sync_mitigates_mispricing() {
     let donation_a = 100u128;


### PR DESCRIPTION
All other entry functions validate the pools fee tier, except for this function. This is likely because it doesn't make use of the fees.

To make the code consistent (and auditing easier), we're now validating the fees in `sync_reserves` the same way.