### PR TITLE
Fix IDL/SPEL account metadata

### DIFF
--- a/artifacts/amm-idl.json
+++ b/artifacts/amm-idl.json
@@ -7,9 +7,9 @@
       "accounts": [
         {
           "name": "config",
-          "writable": false,
+          "writable": true,
           "signer": false,
-          "init": false
+          "init": true
         }
       ],
       "args": [
@@ -32,14 +32,14 @@
       "accounts": [
         {
           "name": "config",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "authority",
           "writable": false,
-          "signer": false,
+          "signer": true,
           "init": false
         }
       ],
@@ -87,9 +87,9 @@
         },
         {
           "name": "price_observations",
-          "writable": false,
+          "writable": true,
           "signer": false,
-          "init": false
+          "init": true
         },
         {
           "name": "clock",
@@ -122,9 +122,9 @@
         },
         {
           "name": "oracle_price_account",
-          "writable": false,
+          "writable": true,
           "signer": false,
-          "init": false
+          "init": true
         },
         {
           "name": "clock",
@@ -151,57 +151,57 @@
         },
         {
           "name": "pool",
-          "writable": false,
+          "writable": true,
           "signer": false,
-          "init": false
+          "init": true
         },
         {
           "name": "vault_a",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "vault_b",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "pool_definition_lp",
-          "writable": false,
+          "writable": true,
           "signer": false,
-          "init": false
+          "init": true
         },
         {
           "name": "lp_lock_holding",
-          "writable": false,
+          "writable": true,
           "signer": false,
-          "init": false
+          "init": true
         },
         {
           "name": "user_holding_a",
-          "writable": false,
-          "signer": false,
+          "writable": true,
+          "signer": true,
           "init": false
         },
         {
           "name": "user_holding_b",
-          "writable": false,
-          "signer": false,
+          "writable": true,
+          "signer": true,
           "init": false
         },
         {
           "name": "user_holding_lp",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "current_tick_account",
-          "writable": false,
+          "writable": true,
           "signer": false,
-          "init": false
+          "init": true
         },
         {
           "name": "clock",
@@ -240,49 +240,49 @@
         },
         {
           "name": "pool",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "vault_a",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "vault_b",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "pool_definition_lp",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "user_holding_a",
-          "writable": false,
-          "signer": false,
+          "writable": true,
+          "signer": true,
           "init": false
         },
         {
           "name": "user_holding_b",
-          "writable": false,
-          "signer": false,
+          "writable": true,
+          "signer": true,
           "init": false
         },
         {
           "name": "user_holding_lp",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "current_tick_account",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
@@ -323,49 +323,49 @@
         },
         {
           "name": "pool",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "vault_a",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "vault_b",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "pool_definition_lp",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "user_holding_a",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "user_holding_b",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "user_holding_lp",
-          "writable": false,
-          "signer": false,
+          "writable": true,
+          "signer": true,
           "init": false
         },
         {
           "name": "current_tick_account",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
@@ -406,37 +406,37 @@
         },
         {
           "name": "pool",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "vault_a",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "vault_b",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "user_holding_a",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "user_holding_b",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "current_tick_account",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
@@ -477,37 +477,37 @@
         },
         {
           "name": "pool",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "vault_a",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "vault_b",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "user_holding_a",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "user_holding_b",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "current_tick_account",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
@@ -548,7 +548,7 @@
         },
         {
           "name": "pool",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
@@ -566,7 +566,7 @@
         },
         {
           "name": "current_tick_account",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },

--- a/artifacts/ata-idl.json
+++ b/artifacts/ata-idl.json
@@ -7,7 +7,7 @@
       "accounts": [
         {
           "name": "owner",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
@@ -19,7 +19,7 @@
         },
         {
           "name": "ata_account",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         }
@@ -37,18 +37,18 @@
         {
           "name": "owner",
           "writable": false,
-          "signer": false,
+          "signer": true,
           "init": false
         },
         {
           "name": "sender_ata",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "recipient",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         }
@@ -70,18 +70,18 @@
         {
           "name": "owner",
           "writable": false,
-          "signer": false,
+          "signer": true,
           "init": false
         },
         {
           "name": "holder_ata",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "token_definition",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         }

--- a/artifacts/stablecoin-idl.json
+++ b/artifacts/stablecoin-idl.json
@@ -8,25 +8,25 @@
         {
           "name": "owner",
           "writable": false,
-          "signer": false,
+          "signer": true,
           "init": false
         },
         {
           "name": "position",
-          "writable": false,
+          "writable": true,
           "signer": false,
-          "init": false
+          "init": true
         },
         {
           "name": "vault",
-          "writable": false,
+          "writable": true,
           "signer": false,
-          "init": false
+          "init": true
         },
         {
           "name": "user_holding",
-          "writable": false,
-          "signer": false,
+          "writable": true,
+          "signer": true,
           "init": false
         },
         {
@@ -49,24 +49,24 @@
         {
           "name": "owner",
           "writable": false,
-          "signer": false,
+          "signer": true,
           "init": false
         },
         {
           "name": "position",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "vault",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "destination",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         }
@@ -84,25 +84,25 @@
         {
           "name": "owner",
           "writable": false,
-          "signer": false,
+          "signer": true,
           "init": false
         },
         {
           "name": "position",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "stablecoin_definition",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "user_stablecoin_holding",
-          "writable": false,
-          "signer": false,
+          "writable": true,
+          "signer": true,
           "init": false
         }
       ],

--- a/artifacts/token-idl.json
+++ b/artifacts/token-idl.json
@@ -7,13 +7,13 @@
       "accounts": [
         {
           "name": "sender",
-          "writable": false,
-          "signer": false,
+          "writable": true,
+          "signer": true,
           "init": false
         },
         {
           "name": "recipient",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         }
@@ -30,15 +30,15 @@
       "accounts": [
         {
           "name": "definition_target_account",
-          "writable": false,
-          "signer": false,
-          "init": false
+          "writable": true,
+          "signer": true,
+          "init": true
         },
         {
           "name": "holding_target_account",
-          "writable": false,
-          "signer": false,
-          "init": false
+          "writable": true,
+          "signer": true,
+          "init": true
         }
       ],
       "args": [
@@ -57,21 +57,21 @@
       "accounts": [
         {
           "name": "definition_target_account",
-          "writable": false,
-          "signer": false,
-          "init": false
+          "writable": true,
+          "signer": true,
+          "init": true
         },
         {
           "name": "holding_target_account",
-          "writable": false,
-          "signer": false,
-          "init": false
+          "writable": true,
+          "signer": true,
+          "init": true
         },
         {
           "name": "metadata_target_account",
-          "writable": false,
-          "signer": false,
-          "init": false
+          "writable": true,
+          "signer": true,
+          "init": true
         }
       ],
       "args": [
@@ -100,9 +100,9 @@
         },
         {
           "name": "account_to_initialize",
-          "writable": false,
-          "signer": false,
-          "init": false
+          "writable": true,
+          "signer": true,
+          "init": true
         }
       ],
       "args": []
@@ -112,14 +112,14 @@
       "accounts": [
         {
           "name": "definition_account",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "user_holding_account",
-          "writable": false,
-          "signer": false,
+          "writable": true,
+          "signer": true,
           "init": false
         }
       ],
@@ -135,13 +135,13 @@
       "accounts": [
         {
           "name": "definition_account",
-          "writable": false,
-          "signer": false,
+          "writable": true,
+          "signer": true,
           "init": false
         },
         {
           "name": "user_holding_account",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         }
@@ -158,15 +158,15 @@
       "accounts": [
         {
           "name": "master_account",
-          "writable": false,
-          "signer": false,
+          "writable": true,
+          "signer": true,
           "init": false
         },
         {
           "name": "printed_account",
-          "writable": false,
-          "signer": false,
-          "init": false
+          "writable": true,
+          "signer": true,
+          "init": true
         }
       ],
       "args": []

--- a/artifacts/twap_oracle-idl.json
+++ b/artifacts/twap_oracle-idl.json
@@ -7,14 +7,14 @@
       "accounts": [
         {
           "name": "price_observations",
-          "writable": false,
+          "writable": true,
           "signer": false,
-          "init": false
+          "init": true
         },
         {
           "name": "price_source",
           "writable": false,
-          "signer": false,
+          "signer": true,
           "init": false
         },
         {
@@ -40,14 +40,14 @@
       "accounts": [
         {
           "name": "oracle_price_account",
-          "writable": false,
+          "writable": true,
           "signer": false,
-          "init": false
+          "init": true
         },
         {
           "name": "price_source",
           "writable": false,
-          "signer": false,
+          "signer": true,
           "init": false
         },
         {
@@ -81,14 +81,14 @@
       "accounts": [
         {
           "name": "current_tick_account",
-          "writable": false,
+          "writable": true,
           "signer": false,
-          "init": false
+          "init": true
         },
         {
           "name": "price_source",
           "writable": false,
-          "signer": false,
+          "signer": true,
           "init": false
         },
         {
@@ -116,7 +116,7 @@
         },
         {
           "name": "oracle_price_account",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
@@ -149,7 +149,7 @@
       "accounts": [
         {
           "name": "price_observations",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
@@ -182,14 +182,14 @@
       "accounts": [
         {
           "name": "current_tick_account",
-          "writable": false,
+          "writable": true,
           "signer": false,
           "init": false
         },
         {
           "name": "price_source",
           "writable": false,
-          "signer": false,
+          "signer": true,
           "init": false
         },
         {

--- a/programs/amm/methods/guest/src/bin/amm.rs
+++ b/programs/amm/methods/guest/src/bin/amm.rs
@@ -1,4 +1,8 @@
 #![cfg_attr(not(test), no_main)]
+#![allow(
+    clippy::cloned_ref_to_slice_refs,
+    reason = "SPEL macro emits cloned validation slices for one-account instructions"
+)]
 
 use std::num::NonZeroU128;
 
@@ -27,6 +31,7 @@ mod amm {
     #[instruction]
     pub fn initialize(
         ctx: ProgramContext,
+        #[account(init)]
         config: AccountWithMetadata,
         token_program_id: ProgramId,
         twap_oracle_program_id: ProgramId,
@@ -50,7 +55,9 @@ mod amm {
     #[instruction]
     pub fn update_config(
         ctx: ProgramContext,
+        #[account(mut)]
         config: AccountWithMetadata,
+        #[account(signer)]
         authority: AccountWithMetadata,
         token_program_id: Option<ProgramId>,
         twap_oracle_program_id: Option<ProgramId>,
@@ -83,6 +90,7 @@ mod amm {
         config: AccountWithMetadata,
         pool: AccountWithMetadata,
         current_tick_account: AccountWithMetadata,
+        #[account(init)]
         price_observations: AccountWithMetadata,
         clock: AccountWithMetadata,
         window_duration: u64,
@@ -114,6 +122,7 @@ mod amm {
         ctx: ProgramContext,
         config: AccountWithMetadata,
         pool: AccountWithMetadata,
+        #[account(init)]
         oracle_price_account: AccountWithMetadata,
         clock: AccountWithMetadata,
         window_duration: u64,
@@ -140,14 +149,23 @@ mod amm {
     pub fn new_definition(
         ctx: ProgramContext,
         config: AccountWithMetadata,
+        #[account(init)]
         pool: AccountWithMetadata,
+        #[account(mut)]
         vault_a: AccountWithMetadata,
+        #[account(mut)]
         vault_b: AccountWithMetadata,
+        #[account(init)]
         pool_definition_lp: AccountWithMetadata,
+        #[account(init)]
         lp_lock_holding: AccountWithMetadata,
+        #[account(mut, signer)]
         user_holding_a: AccountWithMetadata,
+        #[account(mut, signer)]
         user_holding_b: AccountWithMetadata,
+        #[account(mut)]
         user_holding_lp: AccountWithMetadata,
+        #[account(init)]
         current_tick_account: AccountWithMetadata,
         clock: AccountWithMetadata,
         token_a_amount: u128,
@@ -185,13 +203,21 @@ mod amm {
     pub fn add_liquidity(
         ctx: ProgramContext,
         config: AccountWithMetadata,
+        #[account(mut)]
         pool: AccountWithMetadata,
+        #[account(mut)]
         vault_a: AccountWithMetadata,
+        #[account(mut)]
         vault_b: AccountWithMetadata,
+        #[account(mut)]
         pool_definition_lp: AccountWithMetadata,
+        #[account(mut, signer)]
         user_holding_a: AccountWithMetadata,
+        #[account(mut, signer)]
         user_holding_b: AccountWithMetadata,
+        #[account(mut)]
         user_holding_lp: AccountWithMetadata,
+        #[account(mut)]
         current_tick_account: AccountWithMetadata,
         clock: AccountWithMetadata,
         min_amount_liquidity: u128,
@@ -228,13 +254,21 @@ mod amm {
     pub fn remove_liquidity(
         ctx: ProgramContext,
         config: AccountWithMetadata,
+        #[account(mut)]
         pool: AccountWithMetadata,
+        #[account(mut)]
         vault_a: AccountWithMetadata,
+        #[account(mut)]
         vault_b: AccountWithMetadata,
+        #[account(mut)]
         pool_definition_lp: AccountWithMetadata,
+        #[account(mut)]
         user_holding_a: AccountWithMetadata,
+        #[account(mut)]
         user_holding_b: AccountWithMetadata,
+        #[account(mut, signer)]
         user_holding_lp: AccountWithMetadata,
+        #[account(mut)]
         current_tick_account: AccountWithMetadata,
         clock: AccountWithMetadata,
         remove_liquidity_amount: u128,
@@ -272,11 +306,17 @@ mod amm {
     pub fn swap_exact_input(
         ctx: ProgramContext,
         config: AccountWithMetadata,
+        #[account(mut)]
         pool: AccountWithMetadata,
+        #[account(mut)]
         vault_a: AccountWithMetadata,
+        #[account(mut)]
         vault_b: AccountWithMetadata,
+        #[account(mut)]
         user_holding_a: AccountWithMetadata,
+        #[account(mut)]
         user_holding_b: AccountWithMetadata,
+        #[account(mut)]
         current_tick_account: AccountWithMetadata,
         clock: AccountWithMetadata,
         swap_amount_in: u128,
@@ -311,11 +351,17 @@ mod amm {
     pub fn swap_exact_output(
         ctx: ProgramContext,
         config: AccountWithMetadata,
+        #[account(mut)]
         pool: AccountWithMetadata,
+        #[account(mut)]
         vault_a: AccountWithMetadata,
+        #[account(mut)]
         vault_b: AccountWithMetadata,
+        #[account(mut)]
         user_holding_a: AccountWithMetadata,
+        #[account(mut)]
         user_holding_b: AccountWithMetadata,
+        #[account(mut)]
         current_tick_account: AccountWithMetadata,
         clock: AccountWithMetadata,
         exact_amount_out: u128,
@@ -346,9 +392,14 @@ mod amm {
     pub fn sync_reserves(
         ctx: ProgramContext,
         config: AccountWithMetadata,
+        #[account(mut)]
         pool: AccountWithMetadata,
+        // vault_a / vault_b are only read to compute balances in
+        // amm_program::sync::sync_reserves (their post-states are unchanged
+        // clones), so they are not writable — no `mut` metadata.
         vault_a: AccountWithMetadata,
         vault_b: AccountWithMetadata,
+        #[account(mut)]
         current_tick_account: AccountWithMetadata,
         clock: AccountWithMetadata,
     ) -> SpelResult {

--- a/programs/ata/methods/guest/src/bin/ata.rs
+++ b/programs/ata/methods/guest/src/bin/ata.rs
@@ -22,8 +22,10 @@ mod ata {
     #[instruction]
     pub fn create(
         ctx: ProgramContext,
+        #[account(mut)]
         owner: AccountWithMetadata,
         token_definition: AccountWithMetadata,
+        #[account(mut)]
         ata_account: AccountWithMetadata,
         token_program_id: ProgramId,
     ) -> SpelResult {
@@ -45,8 +47,11 @@ mod ata {
     #[instruction]
     pub fn transfer(
         ctx: ProgramContext,
+        #[account(signer)]
         owner: AccountWithMetadata,
+        #[account(mut)]
         sender_ata: AccountWithMetadata,
+        #[account(mut)]
         recipient: AccountWithMetadata,
         token_program_id: ProgramId,
         amount: u128,
@@ -69,8 +74,11 @@ mod ata {
     #[instruction]
     pub fn burn(
         ctx: ProgramContext,
+        #[account(signer)]
         owner: AccountWithMetadata,
+        #[account(mut)]
         holder_ata: AccountWithMetadata,
+        #[account(mut)]
         token_definition: AccountWithMetadata,
         token_program_id: ProgramId,
         amount: u128,

--- a/programs/stablecoin/methods/guest/src/bin/stablecoin.rs
+++ b/programs/stablecoin/methods/guest/src/bin/stablecoin.rs
@@ -20,9 +20,13 @@ mod stablecoin {
     #[instruction]
     pub fn open_position(
         ctx: ProgramContext,
+        #[account(signer)]
         owner: AccountWithMetadata,
+        #[account(init)]
         position: AccountWithMetadata,
+        #[account(init)]
         vault: AccountWithMetadata,
+        #[account(mut, signer)]
         user_holding: AccountWithMetadata,
         token_definition: AccountWithMetadata,
         collateral_amount: u128,
@@ -53,9 +57,13 @@ mod stablecoin {
     #[instruction]
     pub fn withdraw_collateral(
         ctx: ProgramContext,
+        #[account(signer)]
         owner: AccountWithMetadata,
+        #[account(mut)]
         position: AccountWithMetadata,
+        #[account(mut)]
         vault: AccountWithMetadata,
+        #[account(mut)]
         destination: AccountWithMetadata,
         amount: u128,
     ) -> SpelResult {
@@ -83,9 +91,13 @@ mod stablecoin {
     #[instruction]
     pub fn repay_debt(
         ctx: ProgramContext,
+        #[account(signer)]
         owner: AccountWithMetadata,
+        #[account(mut)]
         position: AccountWithMetadata,
+        #[account(mut)]
         stablecoin_definition: AccountWithMetadata,
+        #[account(mut, signer)]
         user_stablecoin_holding: AccountWithMetadata,
         amount: u128,
     ) -> SpelResult {

--- a/programs/token/methods/guest/src/bin/token.rs
+++ b/programs/token/methods/guest/src/bin/token.rs
@@ -19,7 +19,9 @@ mod token {
     /// Fresh public recipients must be explicitly authorized in the same transaction.
     #[instruction]
     pub fn transfer(
+        #[account(mut, signer)]
         sender: AccountWithMetadata,
+        #[account(mut)]
         recipient: AccountWithMetadata,
         amount_to_transfer: u128,
     ) -> SpelResult {
@@ -34,7 +36,9 @@ mod token {
     /// Definition and holding targets must be uninitialized and authorized.
     #[instruction]
     pub fn new_fungible_definition(
+        #[account(init, signer)]
         definition_target_account: AccountWithMetadata,
+        #[account(init, signer)]
         holding_target_account: AccountWithMetadata,
         name: String,
         total_supply: u128,
@@ -58,8 +62,11 @@ mod token {
     )]
     #[instruction]
     pub fn new_definition_with_metadata(
+        #[account(init, signer)]
         definition_target_account: AccountWithMetadata,
+        #[account(init, signer)]
         holding_target_account: AccountWithMetadata,
+        #[account(init, signer)]
         metadata_target_account: AccountWithMetadata,
         new_definition: token_core::NewTokenDefinition,
         metadata: Box<token_core::NewTokenMetadata>,
@@ -82,6 +89,7 @@ mod token {
     pub fn initialize_account(
         ctx: ProgramContext,
         definition_account: AccountWithMetadata,
+        #[account(init, signer)]
         account_to_initialize: AccountWithMetadata,
     ) -> SpelResult {
         Ok(spel_framework::SpelOutput::execute(
@@ -97,7 +105,9 @@ mod token {
     /// Burn tokens from the holder's account.
     #[instruction]
     pub fn burn(
+        #[account(mut)]
         definition_account: AccountWithMetadata,
+        #[account(mut, signer)]
         user_holding_account: AccountWithMetadata,
         amount_to_burn: u128,
     ) -> SpelResult {
@@ -113,7 +123,9 @@ mod token {
     #[instruction]
     pub fn mint(
         ctx: ProgramContext,
+        #[account(mut, signer)]
         definition_account: AccountWithMetadata,
+        #[account(mut)]
         user_holding_account: AccountWithMetadata,
         amount_to_mint: u128,
     ) -> SpelResult {
@@ -129,7 +141,9 @@ mod token {
     /// The printed copy target must be uninitialized and authorized.
     #[instruction]
     pub fn print_nft(
+        #[account(mut, signer)]
         master_account: AccountWithMetadata,
+        #[account(init, signer)]
         printed_account: AccountWithMetadata,
     ) -> SpelResult {
         Ok(spel_framework::SpelOutput::execute(token_program::print_nft::print_nft(

--- a/programs/twap_oracle/methods/guest/src/bin/twap_oracle.rs
+++ b/programs/twap_oracle/methods/guest/src/bin/twap_oracle.rs
@@ -22,7 +22,9 @@ mod twap_oracle {
     #[instruction]
     pub fn create_price_observations(
         ctx: ProgramContext,
+        #[account(init)]
         price_observations: AccountWithMetadata,
+        #[account(signer)]
         price_source: AccountWithMetadata,
         clock: AccountWithMetadata,
         initial_tick: i32,
@@ -56,7 +58,9 @@ mod twap_oracle {
     #[instruction]
     pub fn create_oracle_price_account(
         ctx: ProgramContext,
+        #[account(init)]
         oracle_price_account: AccountWithMetadata,
+        #[account(signer)]
         price_source: AccountWithMetadata,
         clock: AccountWithMetadata,
         base_asset: AccountId,
@@ -89,7 +93,9 @@ mod twap_oracle {
     #[instruction]
     pub fn create_current_tick_account(
         ctx: ProgramContext,
+        #[account(init)]
         current_tick_account: AccountWithMetadata,
+        #[account(signer)]
         price_source: AccountWithMetadata,
         clock: AccountWithMetadata,
         initial_price: u128,
@@ -118,6 +124,7 @@ mod twap_oracle {
     pub fn publish_price(
         ctx: ProgramContext,
         price_observations: AccountWithMetadata,
+        #[account(mut)]
         oracle_price_account: AccountWithMetadata,
         current_tick_account: AccountWithMetadata,
         clock: AccountWithMetadata,
@@ -145,6 +152,7 @@ mod twap_oracle {
     #[instruction]
     pub fn record_tick(
         ctx: ProgramContext,
+        #[account(mut)]
         price_observations: AccountWithMetadata,
         current_tick_account: AccountWithMetadata,
         clock: AccountWithMetadata,
@@ -173,7 +181,9 @@ mod twap_oracle {
     #[instruction]
     pub fn update_current_tick(
         ctx: ProgramContext,
+        #[account(mut)]
         current_tick_account: AccountWithMetadata,
+        #[account(signer)]
         price_source: AccountWithMetadata,
         clock: AccountWithMetadata,
         price: u128,


### PR DESCRIPTION
## Summary

- Add account metadata across token, ATA, stablecoin, TWAP oracle, and AMM guest entrypoints.
- Regenerate committed IDL artifacts for every affected program.
- Document repository-side limits where runtime behavior is conditional and should not be marked as unconditional IDL metadata.

## Details

This aligns generated IDLs with unconditional runtime account requirements:

| Program | Metadata updates |
| --- | --- |
| token | Marks unconditional signer/init/writable accounts for transfer, definition creation, metadata definition creation, account initialization, burn, mint, and NFT print |
| ATA | Marks owner signers for transfer/burn and writable accounts for create/transfer/burn |
| stablecoin | Marks owner/user signers, position/vault init accounts, and mutable position/token holding accounts |
| TWAP oracle | Marks price source signers, created PDA accounts, and mutable observation/price/current tick accounts |
| AMM | Marks config/pool/vault/LP/current tick mutable or init accounts and user holding signers where required unconditionally |

The generated IDLs now expose the signer/init/writable data that IDL-driven clients need for these unconditional cases.

## Not included

This PR does not add unconditional metadata for account requirements that are conditional at runtime:

- Conditional signer/init accounts, such as fresh token recipients, fresh mint holders, idempotent ATA creation, fresh LP holders, and swap-side-dependent user holdings.
- Existing custom PDA derivations are left unchanged.
- Owner checks remain in runtime code; this PR only updates signer/init/writable metadata emitted by current IDL generation.

## Validation

```bash
cargo +nightly fmt --all -- --check
taplo fmt --check .
RISC0_SKIP_BUILD=1 cargo +1.94.0 clippy --workspace --all-targets -- -D warnings
RISC0_DEV_MODE=1 cargo +1.94.0 test --workspace --exclude integration_tests
RISC0_DEV_MODE=1 cargo +1.94.0 test -p integration_tests
cargo +1.94.0 build -p idl-gen --release
failed=0
for src in programs/*/methods/guest/src/bin/*.rs; do
  program=$(basename "$src" .rs)
  ./target/release/idl-gen "$src" > "/tmp/${program}-idl.json" || failed=1
  diff -u "artifacts/${program}-idl.json" "/tmp/${program}-idl.json" || failed=1
done
test "$failed" = 0
```
