### PR TITLE
Remove metadata/symbol/debug sections from release binaries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,16 @@ Generated IDL files live in `artifacts/`. CI checks that every program under `*/
 
 **Note:** `spel` and `wallet` may use different versions of the wallet package. If `spel --idl <IDL> <PROGRAM_FUNCTION> ...` fails, ensure `seq_poll_timeout_millis` is set in the wallet config at `~/.nssa/wallet`.
 
+For testnet and mainnet deployments, build guest binaries with the release profile in each guest manifest:
+
+```toml
+[profile.release]
+debug = 0
+strip = "symbols"
+```
+
+That profile is part of program identity. After every release build, inspect the binary and update every value that depends on the ImageID before submitting transactions: deployed program IDs, client/config files, PDA-derived account addresses, AMM `token_program_id` and `twap_oracle_program_id`, and ATA `token_program_id` inputs. Do not mix raw or old ImageIDs with release-profile binaries.
+
 ```bash
 # Deploy a program binary to the sequencer
 wallet deploy-program <path-to-binary>

--- a/programs/amm/methods/guest/Cargo.toml
+++ b/programs/amm/methods/guest/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 
 [workspace]
 
+[profile.release]
+debug = 0
+strip = "symbols"
+
 [lints.rust]
 rust_2018_idioms = { level = "deny", priority = -1 }
 # deny (not forbid) so a targeted per-item #[allow] remains possible if ever needed

--- a/programs/ata/methods/guest/Cargo.toml
+++ b/programs/ata/methods/guest/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 
 [workspace]
 
+[profile.release]
+debug = 0
+strip = "symbols"
+
 [lints.rust]
 rust_2018_idioms = { level = "deny", priority = -1 }
 # deny (not forbid) so a targeted per-item #[allow] remains possible if ever needed

--- a/programs/stablecoin/methods/guest/Cargo.toml
+++ b/programs/stablecoin/methods/guest/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 
 [workspace]
 
+[profile.release]
+debug = 0
+strip = "symbols"
+
 [[bin]]
 name = "stablecoin"
 path = "src/bin/stablecoin.rs"

--- a/programs/token/methods/guest/Cargo.toml
+++ b/programs/token/methods/guest/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 
 [workspace]
 
+[profile.release]
+debug = 0
+strip = "symbols"
+
 [lints.rust]
 rust_2018_idioms = { level = "deny", priority = -1 }
 # deny (not forbid) so a targeted per-item #[allow] remains possible if ever needed

--- a/programs/twap_oracle/methods/guest/Cargo.toml
+++ b/programs/twap_oracle/methods/guest/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 
 [workspace]
 
+[profile.release]
+debug = 0
+strip = "symbols"
+
 [[bin]]
 name = "twap_oracle"
 path = "src/bin/twap_oracle.rs"


### PR DESCRIPTION
## Summary

Fixes #204

- add stripped release profiles to all guest crates
- document that release-profile guest binaries are canonical for testnet and
  mainnet deployments
- add release guidance to refresh ImageID-dependent program IDs, configs, and
  PDA inputs after each release build

## Validation

- `taplo fmt --check .`
- `taplo fmt --check programs/*/methods/guest/Cargo.toml`
- `cargo +nightly fmt --all -- --check`
- `RISC0_SKIP_BUILD=1 cargo +1.94.0 clippy --workspace --all-targets -- -D warnings`
- `RISC0_DEV_MODE=1 cargo +1.94.0 test --workspace --exclude integration_tests`
- `RISC0_DEV_MODE=1 cargo +1.94.0 test -p integration_tests`
- `cargo +1.94.0 build -p idl-gen --release`
- IDL drift check for guest programs under `programs/`
- `cargo risczero build --manifest-path programs/amm/methods/guest/Cargo.toml`
- `spel inspect programs/amm/methods/guest/target/riscv32im-risc0-zkvm-elf/docker/amm.bin`

AMM release-profile artifact:

- size: `459996` bytes
- ImageID: `c4ad5271f1d1a076b6c9bcb5ca4e62812c88728b6c3cd00f6634f7305ca5ddf5`

## Release impact

Guest ImageIDs will change after this profile is applied. Before deployment,
inspect each built binary and update every dependent program ID, client/config
reference, and PDA-derived value to the release-profile ImageID.