### PR TITLE
Improve build output to use shared dependencies and better output path

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+target
+programs/*/methods/guest/target
+node_modules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,24 @@ jobs:
         env:
           RISC0_DEV_MODE: 1
 
+  build-programs:
+    name: Build Guest Programs
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Build guest program binaries
+        run: make build-programs
+
+      - name: Check guest program binaries
+        run: |
+          set -eu
+          for manifest in programs/*/methods/guest/Cargo.toml; do
+            program="$(basename "$(dirname "$(dirname "$(dirname "${manifest}")")")")"
+            test -s "target/guest/${program}.bin"
+          done
+
   check-idl:
     name: Check IDL
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 target/
-token/methods/guest/target/
-amm/methods/guest/target/
 *.bin

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,11 +32,27 @@ RISC0_DEV_MODE=1 cargo test -p twap_oracle_program
 # Format
 make fmt
 
-# Build the guest ZK binary (requires risc0 toolchain)
+# Build all guest ZK binaries
+make build-programs
+
+# Build one guest directly only when debugging a single guest build
 cargo risczero build --manifest-path programs/<program>/methods/guest/Cargo.toml
 ```
 
-Built binaries output to: `<program>/methods/guest/target/riscv32im-risc0-zkvm-elf/docker/<program>.bin`
+`make build-programs` uses `scripts/build-guests.sh` and
+`scripts/build-guests.Dockerfile` to compile every guest crate in one Docker
+BuildKit build. Cargo git, registry, and target artifacts are shared through
+BuildKit cache mounts. Each raw guest ELF is packaged into the deployable RISC
+Zero `.bin` format, and only those final program binaries are exported.
+
+Built binaries output to:
+`target/guest/<program>.bin`
+
+Use `RISC0_DOCKER_CONTAINER_TAG` to override the guest builder image tag. Use
+`RISC0_BUILD_CACHE_ID` to isolate BuildKit caches for clean benchmarks or
+parallel experiments. Use `RISC0_DOCKER_BUILD_NETWORK` to opt in to a custom
+Docker build network mode, such as `host`, when the default Docker build
+network is not sufficient.
 
 ## IDL Generation
 
@@ -77,11 +93,14 @@ strip = "symbols"
 That profile is part of program identity. After every release build, inspect the binary and update every value that depends on the ImageID before submitting transactions: deployed program IDs, client/config files, PDA-derived account addresses, AMM `token_program_id` and `twap_oracle_program_id`, and ATA `token_program_id` inputs. Do not mix raw or old ImageIDs with release-profile binaries.
 
 ```bash
+# Build all guest binaries with the shared BuildKit cache
+make build-programs
+
 # Deploy a program binary to the sequencer
-wallet deploy-program <path-to-binary>
+wallet deploy-program target/guest/<program>.bin
 
 # Inspect the ProgramId of a built binary
-spel inspect <path-to-binary>
+spel inspect target/guest/<program>.bin
 ```
 
 ## Workspace Structure

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3134,6 +3134,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-packager"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "risc0-binfmt",
+ "risc0-build",
+]
+
+[[package]]
 name = "risc0-zkos-v1compat"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "programs/stablecoin/methods",
     "programs/integration_tests",
     "tools/idl-gen",
+    "tools/risc0-packager",
 ]
 exclude = [
     "programs/token/methods/guest",

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: clippy clippy-guest clippy-all test integration-test fmt idl
+.PHONY: build-programs clippy clippy-guest clippy-all test integration-test fmt idl
+
+build-programs:
+	./scripts/build-guests.sh
 
 clippy:
 	RISC0_SKIP_BUILD=1 cargo clippy --workspace --all-targets -- -D warnings

--- a/scripts/build-guests.Dockerfile
+++ b/scripts/build-guests.Dockerfile
@@ -1,0 +1,44 @@
+# syntax=docker/dockerfile:1.7
+
+ARG RISC0_DOCKER_CONTAINER_TAG=r0.1.88.0
+FROM risczero/risc0-guest-builder:${RISC0_DOCKER_CONTAINER_TAG} AS build
+ARG RISC0_BUILD_CACHE_ID=lez-programs-risc0-guests
+
+WORKDIR /src
+COPY . .
+
+ENV CARGO_TARGET_DIR=/src/target/risc0-guests
+ENV RISC0_FEATURE_bigint2=""
+ENV CC_riscv32im_risc0_zkvm_elf=/root/.risc0/cpp/bin/riscv32-unknown-elf-gcc
+ENV CFLAGS_riscv32im_risc0_zkvm_elf="-march=rv32im -nostdlib"
+
+RUN --mount=type=cache,id=${RISC0_BUILD_CACHE_ID}-cargo-git,sharing=locked,target=/root/.cargo/git \
+    --mount=type=cache,id=${RISC0_BUILD_CACHE_ID}-cargo-registry,sharing=locked,target=/root/.cargo/registry \
+    --mount=type=cache,id=${RISC0_BUILD_CACHE_ID}-target,sharing=locked,target=/src/target/risc0-guests <<'EOF'
+set -eu
+
+target_triple="riscv32im-risc0-zkvm-elf"
+programs="amm ata stablecoin token twap_oracle"
+unit_separator="$(printf '\037')"
+guest_rustflags="-C${unit_separator}passes=lower-atomic${unit_separator}-C${unit_separator}link-arg=-Ttext=0x00200800${unit_separator}-C${unit_separator}link-arg=--fatal-warnings${unit_separator}-C${unit_separator}panic=abort${unit_separator}--cfg${unit_separator}getrandom_backend=\"custom\""
+export CARGO_ENCODED_RUSTFLAGS="${guest_rustflags}"
+
+for program in ${programs}; do
+    manifest="programs/${program}/methods/guest/Cargo.toml"
+    echo "==> Building ${program}"
+    cargo +risc0 build --release --locked --target "${target_triple}" --manifest-path "${manifest}"
+done
+
+mkdir -p /guest-output
+unset CARGO_ENCODED_RUSTFLAGS
+cargo +risc0 build --locked -p risc0-packager
+packager="${CARGO_TARGET_DIR}/debug/risc0-packager"
+
+for program in ${programs}; do
+    elf="${CARGO_TARGET_DIR}/${target_triple}/release/${program}"
+    "${packager}" "${elf}" "/guest-output/${program}.bin"
+done
+EOF
+
+FROM scratch AS export
+COPY --from=build /guest-output /

--- a/scripts/build-guests.sh
+++ b/scripts/build-guests.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+risc0_tag="${RISC0_DOCKER_CONTAINER_TAG:-r0.1.88.0}"
+cache_id="${RISC0_BUILD_CACHE_ID:-lez-programs-risc0-guests}"
+network_mode="${RISC0_DOCKER_BUILD_NETWORK:-}"
+staging_dir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "${staging_dir}"
+}
+trap cleanup EXIT
+
+network_args=()
+if [[ -n "${network_mode}" ]]; then
+  network_args=(--network "${network_mode}")
+fi
+
+DOCKER_BUILDKIT=1 docker build ${network_args[@]+"${network_args[@]}"} \
+  --build-arg "RISC0_DOCKER_CONTAINER_TAG=${risc0_tag}" \
+  --build-arg "RISC0_BUILD_CACHE_ID=${cache_id}" \
+  --output="${staging_dir}" \
+  -f "${repo_root}/scripts/build-guests.Dockerfile" \
+  "${repo_root}"
+
+out_dir="${repo_root}/target/guest"
+rm -rf "${out_dir}"
+mkdir -p "${out_dir}"
+
+for program in amm ata stablecoin token twap_oracle; do
+  rm -rf "${repo_root}/programs/${program}/methods/guest/target"
+  install -m 0644 "${staging_dir}/${program}.bin" "${out_dir}/${program}.bin"
+done

--- a/tools/risc0-packager/Cargo.toml
+++ b/tools/risc0-packager/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "risc0-packager"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1"
+risc0-binfmt = "=3.0.4"
+risc0-build = "=3.0.5"
+
+[lints]
+workspace = true

--- a/tools/risc0-packager/src/main.rs
+++ b/tools/risc0-packager/src/main.rs
@@ -1,0 +1,52 @@
+use std::{env, ffi::OsString, fs, path::PathBuf};
+
+use anyhow::{bail, Context, Result};
+use risc0_binfmt::ProgramBinary;
+
+fn main() -> Result<()> {
+    let mut args = env::args_os();
+    let command = args
+        .next()
+        .unwrap_or_else(|| OsString::from("risc0-packager"));
+    let input = required_arg(&mut args, &command, "guest ELF")?;
+    let output = required_arg(&mut args, &command, "output .bin")?;
+
+    if args.next().is_some() {
+        bail!(
+            "usage: {} <guest-elf> <output-bin>",
+            command.to_string_lossy()
+        );
+    }
+
+    if let Some(parent) = output
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+
+    let user_elf =
+        fs::read(&input).with_context(|| format!("failed to read {}", input.display()))?;
+    let kernel_elf = risc0_build::GuestOptions::default().kernel();
+    let binary = ProgramBinary::new(&user_elf, &kernel_elf);
+
+    fs::write(&output, binary.encode())
+        .with_context(|| format!("failed to write {}", output.display()))?;
+
+    Ok(())
+}
+
+fn required_arg(
+    args: &mut impl Iterator<Item = OsString>,
+    command: &OsString,
+    name: &str,
+) -> Result<PathBuf> {
+    match args.next() {
+        Some(value) => Ok(PathBuf::from(value)),
+        None => bail!(
+            "missing {name}; usage: {} <guest-elf> <output-bin>",
+            command.to_string_lossy()
+        ),
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #211

- Add `make build-programs` as the repo-level command for building every RISC
  Zero guest program binary.
- Build `amm`, `ata`, `stablecoin`, `token`, and `twap_oracle` in one Docker
  BuildKit build with shared Cargo git, registry, and target cache mounts.
- Package each raw guest ELF into the deployable RISC Zero `.bin` format and
  export only those final program binaries into `target/guest/`.
- Keep per-program guest `target/` directories out of the checkout output; stale
  per-program guest targets are removed when `make build-programs` writes the
  root-level binaries.
- Add `.dockerignore` entries so local target directories and `.git` are not
  sent into the Docker build context.
- Document the shared build path, output locations, and cache/image override
  environment variables.

## Build Output

`make build-programs` writes deployable program binaries to:

```text
target/guest/<program>.bin
```

The exported directory contains only the five deployable `.bin` files. It does
not export raw guest ELFs, `deps`, `.fingerprint`, incremental state, or other
per-program RISC Zero target-tree artifacts.

The shared BuildKit caches are keyed by `RISC0_BUILD_CACHE_ID` and stored in
Docker BuildKit cache storage. By default the cache ID prefix is:

```text
lez-programs-risc0-guests
```

The cache mounts are:

- `${RISC0_BUILD_CACHE_ID}-cargo-git`
- `${RISC0_BUILD_CACHE_ID}-cargo-registry`
- `${RISC0_BUILD_CACHE_ID}-target`

## Benchmarks

Clean full guest build across all programs:

- old per-guest build: `217.78s`
- shared BuildKit build: `70.94s`
- improvement: `146.84s` faster, `67.43%` less wall time, `3.07x` speedup

Ignored workspace build output:

- old per-guest output: `953,390,236` bytes (`927M du -sh`)
- shared-output build: `1,687,512` bytes (`1.7M du -sh`)
- saved: `951,702,724` bytes (`907.61 MiB`)
- reduction: `99.82%`
- old output is `564.97x` larger than the shared-output build

Most of the old checkout footprint is duplicated dependency output:

- old `docker/deps` total: `952,769,542` bytes (`908.63 MiB`)
- shared-output `docker/deps` total: none exported to the checkout
- shared-output branch stores reusable deps in Docker BuildKit cache instead,
  keyed by `RISC0_BUILD_CACHE_ID`

### BuildKit-cache:

- current shared build used fresh cache mounts totaling about `1.431GB`:
  `128.4MB` cargo git cache, `293.3MB` cargo registry cache, and `1.009GB`
  shared target cache
- current shared build exported `1,687,512` bytes (`1.7M du -sh`) into the
  checkout
- old per-guest cache measurement reached `11.4GB` cache plus `759.3MB` exported
  output before a repeated Cargo/libgit2 fetch hang prevented completing the
  final guest in an isolated builder
- using the full old checkout output size with that partial cache gives a lower
  bound of `12.35GB` required by main versus about `1.432GB` required by this
  branch for the fresh cache mounts plus exported output
- observed lower bound: shared build is at least `10.92GB` smaller when counting
  BuildKit cache mounts plus exported output

## Compatibility checks:

- `spel inspect` accepts the generated `target/guest/<program>.bin` outputs for
  all programs.
- `target/guest/ata.bin` from `make build-programs` matched the
  `cargo risczero build` output byte-for-byte in a SHA-256 check.
