### PR TITLE
 build: pin enum-ordinalize to 4.3.2 in the AMM guest lockfile

### DIFF
--- a/programs/amm/methods/guest/Cargo.lock
+++ b/programs/amm/methods/guest/Cargo.lock
@@ -1130,18 +1130,18 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "enum-ordinalize"
-version = "4.4.1"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
+checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
 dependencies = [
  "enum-ordinalize-derive",
 ]
 
 [[package]]
 name = "enum-ordinalize-derive"
-version = "4.4.1"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
+checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
The AMM guest lockfile had drifted to enum-ordinalize 4.4.1 (and enum-ordinalize-derive 4.4.1), both of which require rustc 1.89. The RISC Zero guest toolchain is 1.88.0-dev, so `cargo +risc0 build --locked` failed the "build programs" CI task:

    error: rustc 1.88.0-dev is not supported by the following packages:
      enum-ordinalize@4.4.1 requires rustc 1.89
      enum-ordinalize-derive@4.4.1 requires rustc 1.89

enum-ordinalize is pulled in transitively via educe 0.6.0 (^4.3), so 4.3.2 satisfies the requirement and matches what every other guest lockfile already resolves to. Pin both crates back to 4.3.2.

The host workspace Cargo.lock keeps 4.4.1 — it builds on 1.94.0 per rust-toolchain.toml and is unaffected.