### PR TITLE
build(deps): bump spel to v0.6.0 and logos-execution-zone to v0.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 *.bin
 **/*/result
+**/*/.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,7 +708,7 @@ dependencies = [
 [[package]]
 name = "build_utils"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc6#e37876a64028a335eb693198a1ed6a0e875ec5b4"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -861,7 +861,7 @@ dependencies = [
 [[package]]
 name = "clock_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc6#e37876a64028a335eb693198a1ed6a0e875ec5b4"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
 dependencies = [
  "borsh",
  "lee_core",
@@ -2216,7 +2216,7 @@ dependencies = [
 [[package]]
 name = "lee"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc6#e37876a64028a335eb693198a1ed6a0e875ec5b4"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2237,7 +2237,7 @@ dependencies = [
 [[package]]
 name = "lee_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc6#e37876a64028a335eb693198a1ed6a0e875ec5b4"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
 dependencies = [
  "base58",
  "borsh",
@@ -3691,8 +3691,8 @@ dependencies = [
 
 [[package]]
 name = "spel-framework-core"
-version = "0.5.0"
-source = "git+https://github.com/0x-r4bbit/spel.git?rev=91023c9115bf88173b0d25d2e905f2a55ef0313b#91023c9115bf88173b0d25d2e905f2a55ef0313b"
+version = "0.6.0"
+source = "git+https://github.com/logos-co/spel.git?tag=v0.6.0#0cb7e0980535af619482cf1c823f4d394b3ebd61"
 dependencies = [
  "base58",
  "borsh",
@@ -3708,8 +3708,8 @@ dependencies = [
 
 [[package]]
 name = "spel-framework-macros"
-version = "0.5.0"
-source = "git+https://github.com/0x-r4bbit/spel.git?rev=91023c9115bf88173b0d25d2e905f2a55ef0313b#91023c9115bf88173b0d25d2e905f2a55ef0313b"
+version = "0.6.0"
+source = "git+https://github.com/logos-co/spel.git?tag=v0.6.0#0cb7e0980535af619482cf1c823f4d394b3ebd61"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ exclude = [
 resolver = "2"
 
 [workspace.dependencies]
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc6", features = ["host"], package = "lee_core" }
-nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc6", features = ["test-utils"], package = "lee" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", features = ["host"], package = "lee_core" }
+nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", features = ["test-utils"], package = "lee" }
 token_core = { path = "programs/token/core" }
 token_program = { path = "programs/token" }
 amm_core = { path = "programs/amm/core" }

--- a/programs/amm/Cargo.toml
+++ b/programs/amm/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 workspace = true
 
 [dependencies]
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc6", features = ["host"], package = "lee_core" }
-clock_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc6" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", features = ["host"], package = "lee_core" }
+clock_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0" }
 amm_core = { path = "core" }
 token_core = { path = "../token/core" }
 twap_oracle_core = { path = "../twap_oracle/core" }

--- a/programs/amm/core/Cargo.toml
+++ b/programs/amm/core/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 workspace = true
 
 [dependencies]
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc6", features = ["host"], package = "lee_core" }
-spel-framework-macros = { git = "https://github.com/0x-r4bbit/spel.git", rev = "91023c9115bf88173b0d25d2e905f2a55ef0313b", package = "spel-framework-macros" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", features = ["host"], package = "lee_core" }
+spel-framework-macros = { git = "https://github.com/logos-co/spel.git", tag = "v0.6.0", package = "spel-framework-macros" }
 token_core = { path = "../../token/core" }
 borsh = { version = "1.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/programs/amm/methods/guest/Cargo.lock
+++ b/programs/amm/methods/guest/Cargo.lock
@@ -751,7 +751,7 @@ dependencies = [
 [[package]]
 name = "clock_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc6#e37876a64028a335eb693198a1ed6a0e875ec5b4"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
 dependencies = [
  "borsh",
  "lee_core",
@@ -1637,7 +1637,7 @@ dependencies = [
 [[package]]
 name = "lee_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc6#e37876a64028a335eb693198a1ed6a0e875ec5b4"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
 dependencies = [
  "base58",
  "borsh",
@@ -2639,8 +2639,8 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "spel-framework"
-version = "0.5.0"
-source = "git+https://github.com/0x-r4bbit/spel.git?rev=91023c9115bf88173b0d25d2e905f2a55ef0313b#91023c9115bf88173b0d25d2e905f2a55ef0313b"
+version = "0.6.0"
+source = "git+https://github.com/logos-co/spel.git?tag=v0.6.0#0cb7e0980535af619482cf1c823f4d394b3ebd61"
 dependencies = [
  "borsh",
  "lee_core",
@@ -2651,8 +2651,8 @@ dependencies = [
 
 [[package]]
 name = "spel-framework-core"
-version = "0.5.0"
-source = "git+https://github.com/0x-r4bbit/spel.git?rev=91023c9115bf88173b0d25d2e905f2a55ef0313b#91023c9115bf88173b0d25d2e905f2a55ef0313b"
+version = "0.6.0"
+source = "git+https://github.com/logos-co/spel.git?tag=v0.6.0#0cb7e0980535af619482cf1c823f4d394b3ebd61"
 dependencies = [
  "base58",
  "borsh",
@@ -2668,8 +2668,8 @@ dependencies = [
 
 [[package]]
 name = "spel-framework-macros"
-version = "0.5.0"
-source = "git+https://github.com/0x-r4bbit/spel.git?rev=91023c9115bf88173b0d25d2e905f2a55ef0313b#91023c9115bf88173b0d25d2e905f2a55ef0313b"
+version = "0.6.0"
+source = "git+https://github.com/logos-co/spel.git?tag=v0.6.0#0cb7e0980535af619482cf1c823f4d394b3ebd61"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/programs/amm/methods/guest/Cargo.toml
+++ b/programs/amm/methods/guest/Cargo.toml
@@ -56,8 +56,8 @@ name = "amm"
 path = "src/bin/amm.rs"
 
 [dependencies]
-spel-framework = { git = "https://github.com/0x-r4bbit/spel.git", rev = "91023c9115bf88173b0d25d2e905f2a55ef0313b", package = "spel-framework" }
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc6", package = "lee_core" }
+spel-framework = { git = "https://github.com/logos-co/spel.git", tag = "v0.6.0", package = "spel-framework" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", package = "lee_core" }
 risc0-zkvm = { version = "=3.0.5", default-features = false }
 amm_core = { path = "../../core" }
 amm_program = { path = "../..", package = "amm_program" }

--- a/programs/ata/Cargo.toml
+++ b/programs/ata/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 workspace = true
 
 [dependencies]
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc6", features = ["host"], package = "lee_core" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", features = ["host"], package = "lee_core" }
 ata_core = { path = "core" }
 token_core = { path = "../token/core" }

--- a/programs/ata/core/Cargo.toml
+++ b/programs/ata/core/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 workspace = true
 
 [dependencies]
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc6", features = ["host"], package = "lee_core" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", features = ["host"], package = "lee_core" }
 borsh = { version = "1.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 risc0-zkvm = { version = "=3.0.5", default-features = false }

--- a/programs/ata/methods/guest/Cargo.lock
+++ b/programs/ata/methods/guest/Cargo.lock
@@ -1099,7 +1099,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lee_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc6#e37876a64028a335eb693198a1ed6a0e875ec5b4"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
 dependencies = [
  "base58",
  "borsh",
@@ -1855,8 +1855,8 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "spel-framework"
-version = "0.5.0"
-source = "git+https://github.com/0x-r4bbit/spel.git?rev=91023c9115bf88173b0d25d2e905f2a55ef0313b#91023c9115bf88173b0d25d2e905f2a55ef0313b"
+version = "0.6.0"
+source = "git+https://github.com/logos-co/spel.git?tag=v0.6.0#0cb7e0980535af619482cf1c823f4d394b3ebd61"
 dependencies = [
  "borsh",
  "lee_core",
@@ -1867,8 +1867,8 @@ dependencies = [
 
 [[package]]
 name = "spel-framework-core"
-version = "0.5.0"
-source = "git+https://github.com/0x-r4bbit/spel.git?rev=91023c9115bf88173b0d25d2e905f2a55ef0313b#91023c9115bf88173b0d25d2e905f2a55ef0313b"
+version = "0.6.0"
+source = "git+https://github.com/logos-co/spel.git?tag=v0.6.0#0cb7e0980535af619482cf1c823f4d394b3ebd61"
 dependencies = [
  "base58",
  "borsh",
@@ -1884,8 +1884,8 @@ dependencies = [
 
 [[package]]
 name = "spel-framework-macros"
-version = "0.5.0"
-source = "git+https://github.com/0x-r4bbit/spel.git?rev=91023c9115bf88173b0d25d2e905f2a55ef0313b#91023c9115bf88173b0d25d2e905f2a55ef0313b"
+version = "0.6.0"
+source = "git+https://github.com/logos-co/spel.git?tag=v0.6.0#0cb7e0980535af619482cf1c823f4d394b3ebd61"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/programs/ata/methods/guest/Cargo.toml
+++ b/programs/ata/methods/guest/Cargo.toml
@@ -56,8 +56,8 @@ name = "ata"
 path = "src/bin/ata.rs"
 
 [dependencies]
-spel-framework = { git = "https://github.com/0x-r4bbit/spel.git", rev = "91023c9115bf88173b0d25d2e905f2a55ef0313b", package = "spel-framework" }
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc6", package = "lee_core" }
+spel-framework = { git = "https://github.com/logos-co/spel.git", tag = "v0.6.0", package = "spel-framework" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", package = "lee_core" }
 risc0-zkvm = { version = "=3.0.5", default-features = false }
 # Pin ruint (transitive via risc0-binfmt) below 1.18, which raised its MSRV to
 # rustc 1.90. The risc0 guest toolchain ships rustc 1.88, so 1.18+ fails the

--- a/programs/benchmark/Cargo.lock
+++ b/programs/benchmark/Cargo.lock
@@ -688,7 +688,7 @@ dependencies = [
 [[package]]
 name = "build_utils"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc6#e37876a64028a335eb693198a1ed6a0e875ec5b4"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -843,7 +843,7 @@ dependencies = [
 [[package]]
 name = "clock_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc6#e37876a64028a335eb693198a1ed6a0e875ec5b4"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
 dependencies = [
  "borsh",
  "lee_core",
@@ -2437,7 +2437,7 @@ dependencies = [
 [[package]]
 name = "lee"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc6#e37876a64028a335eb693198a1ed6a0e875ec5b4"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2458,7 +2458,7 @@ dependencies = [
 [[package]]
 name = "lee_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc6#e37876a64028a335eb693198a1ed6a0e875ec5b4"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
 dependencies = [
  "base58",
  "borsh",
@@ -4357,8 +4357,8 @@ dependencies = [
 
 [[package]]
 name = "spel-framework-core"
-version = "0.5.0"
-source = "git+https://github.com/0x-r4bbit/spel.git?branch=refactor%2Flez-v020-compat#91023c9115bf88173b0d25d2e905f2a55ef0313b"
+version = "0.6.0"
+source = "git+https://github.com/logos-co/spel.git?tag=v0.6.0#0cb7e0980535af619482cf1c823f4d394b3ebd61"
 dependencies = [
  "base58",
  "borsh",
@@ -4374,8 +4374,8 @@ dependencies = [
 
 [[package]]
 name = "spel-framework-macros"
-version = "0.5.0"
-source = "git+https://github.com/0x-r4bbit/spel.git?branch=refactor%2Flez-v020-compat#91023c9115bf88173b0d25d2e905f2a55ef0313b"
+version = "0.6.0"
+source = "git+https://github.com/logos-co/spel.git?tag=v0.6.0#0cb7e0980535af619482cf1c823f4d394b3ebd61"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/programs/benchmark/Cargo.toml
+++ b/programs/benchmark/Cargo.toml
@@ -11,9 +11,9 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc6", package = "lee" }
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc6", features = ["host"], package = "lee_core" }
-clock_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc6" }
+nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", package = "lee" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", features = ["host"], package = "lee_core" }
+clock_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0" }
 twap_oracle_core = { path = "../twap_oracle/core" }
 twap-oracle-methods = { path = "../twap_oracle/methods" }
 # `prove` exposes `ExecutorImpl`/`Session` (the cycle split); we only execute, never prove.

--- a/programs/integration_tests/Cargo.toml
+++ b/programs/integration_tests/Cargo.toml
@@ -9,7 +9,7 @@ workspace = true
 [dependencies]
 nssa = { workspace = true }
 nssa_core = { workspace = true, features = ["host", "test_utils"] }
-clock_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc6" }
+clock_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0" }
 amm_core = { workspace = true }
 token_core = { workspace = true }
 ata_core = { workspace = true }

--- a/programs/stablecoin/Cargo.toml
+++ b/programs/stablecoin/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc6", features = ["host"], package = "lee_core" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", features = ["host"], package = "lee_core" }
 stablecoin_core = { path = "core" }
 token_core = { path = "../token/core" }

--- a/programs/stablecoin/core/Cargo.toml
+++ b/programs/stablecoin/core/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc6", features = ["host"], package = "lee_core" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", features = ["host"], package = "lee_core" }
 borsh = { version = "1.5", features = ["derive"] }
 alloy-primitives = { version = "1", default-features = false }
 # Pin ruint (transitive via alloy-primitives) below 1.18, which raised its MSRV to rustc 1.90.
@@ -14,4 +14,4 @@ ruint = { version = "=1.17.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 twap_oracle_core = { path = "../../twap_oracle/core" }
 risc0-zkvm = { version = "=3.0.5", default-features = false }
-spel-framework-macros = { git = "https://github.com/0x-r4bbit/spel.git", rev = "91023c9115bf88173b0d25d2e905f2a55ef0313b", package = "spel-framework-macros" }
+spel-framework-macros = { git = "https://github.com/logos-co/spel.git", tag = "v0.6.0", package = "spel-framework-macros" }

--- a/programs/stablecoin/methods/guest/Cargo.lock
+++ b/programs/stablecoin/methods/guest/Cargo.lock
@@ -1588,7 +1588,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lee_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc6#e37876a64028a335eb693198a1ed6a0e875ec5b4"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
 dependencies = [
  "base58",
  "borsh",
@@ -2600,8 +2600,8 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "spel-framework"
-version = "0.5.0"
-source = "git+https://github.com/0x-r4bbit/spel.git?rev=91023c9115bf88173b0d25d2e905f2a55ef0313b#91023c9115bf88173b0d25d2e905f2a55ef0313b"
+version = "0.6.0"
+source = "git+https://github.com/logos-co/spel.git?tag=v0.6.0#0cb7e0980535af619482cf1c823f4d394b3ebd61"
 dependencies = [
  "borsh",
  "lee_core",
@@ -2612,8 +2612,8 @@ dependencies = [
 
 [[package]]
 name = "spel-framework-core"
-version = "0.5.0"
-source = "git+https://github.com/0x-r4bbit/spel.git?rev=91023c9115bf88173b0d25d2e905f2a55ef0313b#91023c9115bf88173b0d25d2e905f2a55ef0313b"
+version = "0.6.0"
+source = "git+https://github.com/logos-co/spel.git?tag=v0.6.0#0cb7e0980535af619482cf1c823f4d394b3ebd61"
 dependencies = [
  "base58",
  "borsh",
@@ -2629,8 +2629,8 @@ dependencies = [
 
 [[package]]
 name = "spel-framework-macros"
-version = "0.5.0"
-source = "git+https://github.com/0x-r4bbit/spel.git?rev=91023c9115bf88173b0d25d2e905f2a55ef0313b#91023c9115bf88173b0d25d2e905f2a55ef0313b"
+version = "0.6.0"
+source = "git+https://github.com/logos-co/spel.git?tag=v0.6.0#0cb7e0980535af619482cf1c823f4d394b3ebd61"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/programs/stablecoin/methods/guest/Cargo.toml
+++ b/programs/stablecoin/methods/guest/Cargo.toml
@@ -14,8 +14,8 @@ name = "stablecoin"
 path = "src/bin/stablecoin.rs"
 
 [dependencies]
-spel-framework = { git = "https://github.com/0x-r4bbit/spel.git", rev = "91023c9115bf88173b0d25d2e905f2a55ef0313b", package = "spel-framework" }
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc6", package = "lee_core" }
+spel-framework = { git = "https://github.com/logos-co/spel.git", tag = "v0.6.0", package = "spel-framework" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", package = "lee_core" }
 risc0-zkvm = { version = "=3.0.5", default-features = false }
 twap_oracle_core = { path = "../../../twap_oracle/core" }
 stablecoin_core = { path = "../../core" }

--- a/programs/token/Cargo.toml
+++ b/programs/token/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 workspace = true
 
 [dependencies]
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc6", features = ["host"], package = "lee_core" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", features = ["host"], package = "lee_core" }
 token_core = { path = "core" }

--- a/programs/token/core/Cargo.toml
+++ b/programs/token/core/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 workspace = true
 
 [dependencies]
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc6", features = ["host"], package = "lee_core" }
-spel-framework-macros = { git = "https://github.com/0x-r4bbit/spel.git", rev = "91023c9115bf88173b0d25d2e905f2a55ef0313b", package = "spel-framework-macros" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", features = ["host"], package = "lee_core" }
+spel-framework-macros = { git = "https://github.com/logos-co/spel.git", tag = "v0.6.0", package = "spel-framework-macros" }
 borsh = { version = "1.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/programs/token/methods/guest/Cargo.lock
+++ b/programs/token/methods/guest/Cargo.lock
@@ -1065,7 +1065,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lee_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc6#e37876a64028a335eb693198a1ed6a0e875ec5b4"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
 dependencies = [
  "base58",
  "borsh",
@@ -1821,8 +1821,8 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "spel-framework"
-version = "0.5.0"
-source = "git+https://github.com/0x-r4bbit/spel.git?rev=91023c9115bf88173b0d25d2e905f2a55ef0313b#91023c9115bf88173b0d25d2e905f2a55ef0313b"
+version = "0.6.0"
+source = "git+https://github.com/logos-co/spel.git?tag=v0.6.0#0cb7e0980535af619482cf1c823f4d394b3ebd61"
 dependencies = [
  "borsh",
  "lee_core",
@@ -1833,8 +1833,8 @@ dependencies = [
 
 [[package]]
 name = "spel-framework-core"
-version = "0.5.0"
-source = "git+https://github.com/0x-r4bbit/spel.git?rev=91023c9115bf88173b0d25d2e905f2a55ef0313b#91023c9115bf88173b0d25d2e905f2a55ef0313b"
+version = "0.6.0"
+source = "git+https://github.com/logos-co/spel.git?tag=v0.6.0#0cb7e0980535af619482cf1c823f4d394b3ebd61"
 dependencies = [
  "base58",
  "borsh",
@@ -1850,8 +1850,8 @@ dependencies = [
 
 [[package]]
 name = "spel-framework-macros"
-version = "0.5.0"
-source = "git+https://github.com/0x-r4bbit/spel.git?rev=91023c9115bf88173b0d25d2e905f2a55ef0313b#91023c9115bf88173b0d25d2e905f2a55ef0313b"
+version = "0.6.0"
+source = "git+https://github.com/logos-co/spel.git?tag=v0.6.0#0cb7e0980535af619482cf1c823f4d394b3ebd61"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/programs/token/methods/guest/Cargo.toml
+++ b/programs/token/methods/guest/Cargo.toml
@@ -56,8 +56,8 @@ name = "token"
 path = "src/bin/token.rs"
 
 [dependencies]
-spel-framework = { git = "https://github.com/0x-r4bbit/spel.git", rev = "91023c9115bf88173b0d25d2e905f2a55ef0313b", package = "spel-framework" }
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc6", package = "lee_core" }
+spel-framework = { git = "https://github.com/logos-co/spel.git", tag = "v0.6.0", package = "spel-framework" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", package = "lee_core" }
 risc0-zkvm = { version = "=3.0.5", default-features = false }
 # Pin ruint (transitive via risc0-binfmt) below 1.18, which raised its MSRV to
 # rustc 1.90. The risc0 guest toolchain ships rustc 1.88, so 1.18+ fails the

--- a/programs/twap_oracle/Cargo.toml
+++ b/programs/twap_oracle/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc6", features = ["host"], package = "lee_core" }
-clock_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc6" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", features = ["host"], package = "lee_core" }
+clock_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0" }
 twap_oracle_core = { path = "core" }
 
 [lints]

--- a/programs/twap_oracle/core/Cargo.toml
+++ b/programs/twap_oracle/core/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2021"
 workspace = true
 
 [dependencies]
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc6", features = ["host"], package = "lee_core" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", features = ["host"], package = "lee_core" }
 borsh = { version = "1.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
-spel-framework-macros = { git = "https://github.com/0x-r4bbit/spel.git", rev = "91023c9115bf88173b0d25d2e905f2a55ef0313b", package = "spel-framework-macros" }
+spel-framework-macros = { git = "https://github.com/logos-co/spel.git", tag = "v0.6.0", package = "spel-framework-macros" }
 risc0-zkvm = { version = "=3.0.5", default-features = false }
 uniswap_v3_math = "0.6.2"
 alloy-primitives = { version = "1", default-features = false }

--- a/programs/twap_oracle/methods/guest/Cargo.lock
+++ b/programs/twap_oracle/methods/guest/Cargo.lock
@@ -691,7 +691,7 @@ dependencies = [
 [[package]]
 name = "clock_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc6#e37876a64028a335eb693198a1ed6a0e875ec5b4"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
 dependencies = [
  "borsh",
  "lee_core",
@@ -1597,7 +1597,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lee_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc6#e37876a64028a335eb693198a1ed6a0e875ec5b4"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
 dependencies = [
  "base58",
  "borsh",
@@ -2609,8 +2609,8 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "spel-framework"
-version = "0.5.0"
-source = "git+https://github.com/0x-r4bbit/spel.git?rev=91023c9115bf88173b0d25d2e905f2a55ef0313b#91023c9115bf88173b0d25d2e905f2a55ef0313b"
+version = "0.6.0"
+source = "git+https://github.com/logos-co/spel.git?tag=v0.6.0#0cb7e0980535af619482cf1c823f4d394b3ebd61"
 dependencies = [
  "borsh",
  "lee_core",
@@ -2621,8 +2621,8 @@ dependencies = [
 
 [[package]]
 name = "spel-framework-core"
-version = "0.5.0"
-source = "git+https://github.com/0x-r4bbit/spel.git?rev=91023c9115bf88173b0d25d2e905f2a55ef0313b#91023c9115bf88173b0d25d2e905f2a55ef0313b"
+version = "0.6.0"
+source = "git+https://github.com/logos-co/spel.git?tag=v0.6.0#0cb7e0980535af619482cf1c823f4d394b3ebd61"
 dependencies = [
  "base58",
  "borsh",
@@ -2638,8 +2638,8 @@ dependencies = [
 
 [[package]]
 name = "spel-framework-macros"
-version = "0.5.0"
-source = "git+https://github.com/0x-r4bbit/spel.git?rev=91023c9115bf88173b0d25d2e905f2a55ef0313b#91023c9115bf88173b0d25d2e905f2a55ef0313b"
+version = "0.6.0"
+source = "git+https://github.com/logos-co/spel.git?tag=v0.6.0#0cb7e0980535af619482cf1c823f4d394b3ebd61"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/programs/twap_oracle/methods/guest/Cargo.toml
+++ b/programs/twap_oracle/methods/guest/Cargo.toml
@@ -14,9 +14,9 @@ name = "twap_oracle"
 path = "src/bin/twap_oracle.rs"
 
 [dependencies]
-spel-framework = { git = "https://github.com/0x-r4bbit/spel.git", rev = "91023c9115bf88173b0d25d2e905f2a55ef0313b", package = "spel-framework" }
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc6", package = "lee_core" }
-clock_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc6" }
+spel-framework = { git = "https://github.com/logos-co/spel.git", tag = "v0.6.0", package = "spel-framework" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", package = "lee_core" }
+clock_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0" }
 risc0-zkvm = { version = "=3.0.5", default-features = false }
 twap_oracle_core = { path = "../../core" }
 twap_oracle_program = { path = "../..", package = "twap_oracle_program" }

--- a/tools/idl-gen/Cargo.toml
+++ b/tools/idl-gen/Cargo.toml
@@ -11,7 +11,7 @@ name = "idl-gen"
 path = "src/main.rs"
 
 [dependencies]
-spel-framework-core = { git = "https://github.com/0x-r4bbit/spel.git", rev = "91023c9115bf88173b0d25d2e905f2a55ef0313b", package = "spel-framework-core", features = ["idl-gen"] }
+spel-framework-core = { git = "https://github.com/logos-co/spel.git", tag = "v0.6.0", package = "spel-framework-core", features = ["idl-gen"] }
 # `preserve_order` keeps object keys in struct-declaration order when
 # round-tripping through serde_json::Value (see main.rs), so the only
 # reordering we apply is sorting the `types` array.


### PR DESCRIPTION
Move the spel-framework dependency from the 0x-r4bbit/spel fork (v0.5.0 @ 91023c9, the refactor/lez-v020-compat branch) to the released logos-co/spel tag v0.6.0.

spel v0.6.0 is built against the final logos-execution-zone v0.2.0, not the v0.2.0-rc6 this repo pinned. The two must match: with rc6, the guest ELF build fails because spel's lee_core::program::ValidityWindow and the repo's own copy are distinct types the #[lez_program] macro can't unify. So this also bumps every logos-execution-zone pin (lee/lee_core aliased as nssa/nssa_core, plus clock_core) from v0.2.0-rc6 to the final v0.2.0.

- 10 Cargo.toml switched to logos-co/spel tag v0.6.0
- 24 logos-execution-zone pins across 18 Cargo.toml moved rc6 -> v0.2.0
- All 7 Cargo.lock files re-resolved (root + 5 guest workspaces + benchmark); pulls in lee_core v0.1.0 (v0.2.0) as a spel transitive dep

Guest ImageIDs change as a result: the ID hashes the whole guest ELF, which links the updated spel-framework and lee_core object code, even though the program sources are unchanged. Update any ImageID-derived values (deployed program IDs, PDA addresses, AMM/ATA program-id inputs) before submitting transactions.