### PR TITLE
refactor(modules/amm): rename swap_plan to swap_exact_in_plan

### DIFF
--- a/modules/amm/ffi/include/amm_ffi.h
+++ b/modules/amm/ffi/include/amm_ffi.h
@@ -36,7 +36,7 @@ char *amm_swap_exact_in_quote(const char *request_json);
 
 char *amm_swap_exact_out_quote(const char *request_json);
 
-char *amm_swap_plan(const char *request_json);
+char *amm_swap_exact_in_plan(const char *request_json);
 
 char *amm_program_id(const char *request_json);
 

--- a/modules/amm/ffi/src/api/mod.rs
+++ b/modules/amm/ffi/src/api/mod.rs
@@ -22,8 +22,8 @@ use std::{error::Error, fmt};
 
 pub use request::{
     ConfigIdRequest, ContextRequest, PairIdsRequest, PairSnapshot, PlanRequest, PoolIdRequest,
-    PositionRequest, ProgramIdRequest, QuoteRequest, ResolvePoolRequest, SwapExactInQuoteRequest,
-    SwapExactOutQuoteRequest, SwapPairRequest, SwapPlanRequest, TokenIdsRequest,
+    PositionRequest, ProgramIdRequest, QuoteRequest, ResolvePoolRequest, SwapExactInPlanRequest,
+    SwapExactInQuoteRequest, SwapExactOutQuoteRequest, SwapPairRequest, TokenIdsRequest,
 };
 use serde_json::Value;
 
@@ -119,8 +119,8 @@ pub fn swap_exact_out_quote(request: SwapExactOutQuoteRequest) -> AmmResult {
 }
 
 /// Builds the `SwapExactInput` wallet submission for a token pair.
-pub fn swap_plan(request: SwapPlanRequest) -> AmmResult {
-    swap::swap_plan(request).map_err(Into::into)
+pub fn swap_exact_in_plan(request: SwapExactInPlanRequest) -> AmmResult {
+    swap::swap_exact_in_plan(request).map_err(Into::into)
 }
 
 /// Derives the AMM `ProgramId` (Image ID) from a deployed program binary.

--- a/modules/amm/ffi/src/api/request.rs
+++ b/modules/amm/ffi/src/api/request.rs
@@ -101,7 +101,7 @@ pub struct PoolIdRequest {
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
-pub struct SwapPlanRequest {
+pub struct SwapExactInPlanRequest {
     pub amm_program_id: String,
     pub token_in_id: String,
     pub token_out_id: String,

--- a/modules/amm/ffi/src/api/request.rs
+++ b/modules/amm/ffi/src/api/request.rs
@@ -111,6 +111,10 @@ pub struct SwapExactInPlanRequest {
     pub amount_in: String,
     pub min_out: String,
     pub deadline_ms: String,
+    /// Pool account data (hex Borsh `PoolDefinition`) — its stored `vault_a_id` /
+    /// `vault_b_id` are used verbatim (the guest asserts the vaults in the pool's
+    /// creation order, which needn't match the canonical token order).
+    pub pool_data: String,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]

--- a/modules/amm/ffi/src/api/swap.rs
+++ b/modules/amm/ffi/src/api/swap.rs
@@ -287,6 +287,18 @@ pub(super) fn swap_exact_in_plan(request: SwapExactInPlanRequest) -> Result<Valu
         return Ok(json!({ "status": "error", "code": "config_unavailable" }));
     };
 
+    // Take the vaults from the pool's STORED ids, in its `def_a`/`def_b` (creation)
+    // order — the guest asserts the provided vaults against `pool.vault_a_id` /
+    // `vault_b_id`, which needn't match `derive_pair`'s canonical order for a
+    // non-canonically created pool. (`pair.pool`/`current_tick`/`clock` are
+    // order-independent, so they still come from `derive_pair`.)
+    let Some(pool) = hex::decode(&request.pool_data)
+        .ok()
+        .and_then(|bytes| borsh::from_slice::<PoolDefinition>(&bytes).ok())
+    else {
+        return Ok(json!({ "status": "error", "code": "no_pool" }));
+    };
+
     let user_input_holding =
         account_id_from_hex(&request.user_input_holding_id, "user input holding id")?;
     let user_output_holding =
@@ -307,8 +319,8 @@ pub(super) fn swap_exact_in_plan(request: SwapExactInPlanRequest) -> Result<Valu
     let account_ids = [
         pair.config,
         pair.pool,
-        pair.vault_a,
-        pair.vault_b,
+        pool.vault_a_id,
+        pool.vault_b_id,
         user_input_holding,
         user_output_holding,
         pair.current_tick,
@@ -434,6 +446,7 @@ mod tests {
             amount_in: String::new(),
             min_out: String::new(),
             deadline_ms: String::new(),
+            pool_data: String::new(),
         })
         .unwrap();
         assert_eq!(plan, expected);

--- a/modules/amm/ffi/src/api/swap.rs
+++ b/modules/amm/ffi/src/api/swap.rs
@@ -13,8 +13,8 @@ use serde_json::{json, Value};
 
 use super::{
     pair::{derive_pair, is_canonical_pair},
-    PoolIdRequest, ProgramIdRequest, ResolvePoolRequest, SwapExactInQuoteRequest,
-    SwapExactOutQuoteRequest, SwapPairRequest, SwapPlanRequest,
+    PoolIdRequest, ProgramIdRequest, ResolvePoolRequest, SwapExactInPlanRequest,
+    SwapExactInQuoteRequest, SwapExactOutQuoteRequest, SwapPairRequest,
 };
 use crate::account::{
     account_id_from_hex, account_id_hex, decode_account, parse_program_id, program_id_bytes,
@@ -271,7 +271,7 @@ pub(super) fn swap_exact_out_quote(request: SwapExactOutQuoteRequest) -> Result<
 /// order (vaults canonical, only the user's input holding signs) and the
 /// instruction words (`risc0_zkvm::serde` — the same encoding the guest
 /// decodes). Mirrors `plan.rs`'s `ready` output shape.
-pub(super) fn swap_plan(request: SwapPlanRequest) -> Result<Value, String> {
+pub(super) fn swap_exact_in_plan(request: SwapExactInPlanRequest) -> Result<Value, String> {
     let amm_program = parse_program_id(&request.amm_program_id)?;
     let token_in = account_id_from_hex(&request.token_in_id, "token in id")?;
     let token_out = account_id_from_hex(&request.token_out_id, "token out id")?;
@@ -424,7 +424,7 @@ mod tests {
         .unwrap();
         assert_eq!(pair, expected);
 
-        let plan = swap_plan(SwapPlanRequest {
+        let plan = swap_exact_in_plan(SwapExactInPlanRequest {
             amm_program_id: program,
             token_in_id: same.clone(),
             token_out_id: same,

--- a/modules/amm/ffi/src/api/tests.rs
+++ b/modules/amm/ffi/src/api/tests.rs
@@ -22,8 +22,9 @@ use super::{
     plan::plan,
     position::AccountPlanHoldings,
     quote::{div_ceil_u256, minimum_opening_pair, quote, Q64},
+    swap::swap_exact_in_plan,
     ContextRequest, PairIdsRequest, PairSnapshot, PlanRequest, PositionRequest, QuoteRequest,
-    TokenIdsRequest,
+    SwapExactInPlanRequest, TokenIdsRequest,
 };
 use crate::{
     account::{account_id_hex, account_read, decode_account, parse_base58_id, program_id_bytes},
@@ -699,4 +700,55 @@ fn stale_hash_returns_recomputed_quote_without_plan() {
     assert_eq!(value["status"], "error");
     assert_eq!(value["code"], "quote_changed");
     assert_eq!(value["quote"]["status"], "ok");
+}
+
+#[test]
+fn swap_plan_uses_the_pool_stored_vaults_not_canonical_order() {
+    // A pool created NON-canonically: its stored def_a is the smaller-valued
+    // token, so pool.vault_a_id is the vault for the smaller token — the opposite
+    // of what canonical_pair (larger first) would derive. The plan must emit the
+    // pool's own stored vaults, which is what the guest asserts against.
+    let token_small = AccountId::new([1; 32]);
+    let token_large = AccountId::new([2; 32]);
+    assert!(is_canonical_pair(token_large, token_small)); // large is canonical token_a
+
+    let pool_id = compute_pool_pda(AMM_PROGRAM, token_small, token_large);
+    let pool = PoolDefinition {
+        definition_token_a_id: token_small, // stored non-canonically (small first)
+        definition_token_b_id: token_large,
+        vault_a_id: compute_vault_pda(AMM_PROGRAM, pool_id, token_small),
+        vault_b_id: compute_vault_pda(AMM_PROGRAM, pool_id, token_large),
+        liquidity_pool_id: compute_liquidity_token_pda(AMM_PROGRAM, pool_id),
+        liquidity_pool_supply: 1_000,
+        reserve_a: 1_000,
+        reserve_b: 1_000,
+        fees: 30,
+    };
+
+    let holding = AccountId::new([9; 32]);
+    let plan = swap_exact_in_plan(SwapExactInPlanRequest {
+        amm_program_id: amm_program_id(),
+        token_in_id: account_id_hex(token_small),
+        token_out_id: account_id_hex(token_large),
+        config: account_read(compute_config_pda(AMM_PROGRAM), &config_account()),
+        user_input_holding_id: account_id_hex(holding),
+        user_output_holding_id: account_id_hex(holding),
+        amount_in: String::from("100"),
+        min_out: String::from("0"),
+        deadline_ms: String::from("0"),
+        pool_data: hex::encode(borsh::to_vec(&pool).unwrap()),
+    })
+    .unwrap();
+
+    // Slots 2 and 3 are vault_a / vault_b — in the pool's stored order, not the
+    // canonical order. (A domain error would leave accountIds absent, so these
+    // also assert the plan succeeded.)
+    assert_eq!(plan["accountIds"][2], account_id_hex(pool.vault_a_id));
+    assert_eq!(plan["accountIds"][3], account_id_hex(pool.vault_b_id));
+    // Guard: the stored vault_a genuinely differs from the canonical derivation
+    // (the pre-fix bug would have emitted this one in slot 2).
+    assert_ne!(
+        pool.vault_a_id,
+        compute_vault_pda(AMM_PROGRAM, pool_id, token_large)
+    );
 }

--- a/modules/amm/ffi/src/ffi.rs
+++ b/modules/amm/ffi/src/ffi.rs
@@ -7,8 +7,8 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use crate::api::{
     self, AmmApiError, AmmResult, ConfigIdRequest, ContextRequest, PairIdsRequest, PlanRequest,
-    PoolIdRequest, ProgramIdRequest, QuoteRequest, ResolvePoolRequest, SwapExactInQuoteRequest,
-    SwapExactOutQuoteRequest, SwapPairRequest, SwapPlanRequest, TokenIdsRequest,
+    PoolIdRequest, ProgramIdRequest, QuoteRequest, ResolvePoolRequest, SwapExactInPlanRequest,
+    SwapExactInQuoteRequest, SwapExactOutQuoteRequest, SwapPairRequest, TokenIdsRequest,
 };
 
 #[derive(Serialize)]
@@ -133,8 +133,8 @@ pub extern "C" fn amm_swap_exact_out_quote(request_json: *const c_char) -> *mut 
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn amm_swap_plan(request_json: *const c_char) -> *mut c_char {
-    call::<SwapPlanRequest>(request_json, api::swap_plan)
+pub extern "C" fn amm_swap_exact_in_plan(request_json: *const c_char) -> *mut c_char {
+    call::<SwapExactInPlanRequest>(request_json, api::swap_exact_in_plan)
 }
 
 #[unsafe(no_mangle)]

--- a/modules/amm/ffi/src/lib.rs
+++ b/modules/amm/ffi/src/lib.rs
@@ -7,9 +7,9 @@ pub mod api;
 
 pub use api::{
     config_id, context, pair_ids, plan, pool_id, program_id, quote, resolve_pool,
-    swap_exact_in_quote, swap_exact_out_quote, swap_pair, swap_plan, token_ids, AccountRead,
-    AmmApiError, AmmResponse, AmmResult, ConfigIdRequest, ContextRequest, PairIdsRequest,
-    PairSnapshot, PlanRequest, PoolIdRequest, PositionRequest, ProgramIdRequest, QuoteRequest,
-    ResolvePoolRequest, SwapExactInQuoteRequest, SwapExactOutQuoteRequest, SwapPairRequest,
-    SwapPlanRequest, TokenIdsRequest, WalletAccount,
+    swap_exact_in_plan, swap_exact_in_quote, swap_exact_out_quote, swap_pair, token_ids,
+    AccountRead, AmmApiError, AmmResponse, AmmResult, ConfigIdRequest, ContextRequest,
+    PairIdsRequest, PairSnapshot, PlanRequest, PoolIdRequest, PositionRequest, ProgramIdRequest,
+    QuoteRequest, ResolvePoolRequest, SwapExactInPlanRequest, SwapExactInQuoteRequest,
+    SwapExactOutQuoteRequest, SwapPairRequest, TokenIdsRequest, WalletAccount,
 };

--- a/modules/amm/src/amm_module_impl.cpp
+++ b/modules/amm/src/amm_module_impl.cpp
@@ -609,9 +609,9 @@ std::string AmmModuleImpl::swapExactInput(const std::string& def_a_hex,
         return {};
     }
 
-    // amm_swap_plan resolves the pool, reorders holdings to the pool's canonical
-    // def order, encodes SwapExactInput, and returns a ready-to-submit plan.
-    const FfiResult planResult = call(amm_swap_plan, json{
+    // amm_swap_exact_in_plan resolves the pool, reorders holdings to the pool's
+    // canonical def order, encodes SwapExactInput, and returns a ready-to-submit plan.
+    const FfiResult planResult = call(amm_swap_exact_in_plan, json{
         {"ammProgramId", net.amm_program_id},
         {"tokenInId", def_a_hex},
         {"tokenOutId", def_b_hex},
@@ -623,7 +623,7 @@ std::string AmmModuleImpl::swapExactInput(const std::string& def_a_hex,
         {"deadlineMs", deadline_decimal},
     });
     if (!planResult.ok || jStr(planResult.value, "status") != "ready") {
-        AMM_TRACE("swapExactInput: FAIL amm_swap_plan not ready");
+        AMM_TRACE("swapExactInput: FAIL amm_swap_exact_in_plan not ready");
         return {};
     }
     const json plan = planResult.value;

--- a/modules/amm/src/amm_module_impl.cpp
+++ b/modules/amm/src/amm_module_impl.cpp
@@ -609,13 +609,28 @@ std::string AmmModuleImpl::swapExactInput(const std::string& def_a_hex,
         return {};
     }
 
-    // amm_swap_exact_in_plan resolves the pool, reorders holdings to the pool's
-    // canonical def order, encodes SwapExactInput, and returns a ready-to-submit plan.
+    // Read the pool so the plan can use its stored vault ids (the guest asserts
+    // the vaults in the pool's creation order — see amm_swap_exact_in_plan).
+    const FfiResult poolId = call(amm_pool_id, json{
+        {"ammProgramId", net.amm_program_id},
+        {"tokenInId", def_a_hex},
+        {"tokenOutId", def_b_hex},
+    });
+    if (!poolId.ok) {
+        AMM_TRACE("swapExactInput: FAIL amm_pool_id");
+        return {};
+    }
+    const json pool = readPublicAccount(jStr(poolId.value, "poolId"));
+    const std::string pool_data = jStr(pool.value("account", json::object()), "data");
+
+    // amm_swap_exact_in_plan resolves the pool accounts, encodes SwapExactInput,
+    // and returns a ready-to-submit plan.
     const FfiResult planResult = call(amm_swap_exact_in_plan, json{
         {"ammProgramId", net.amm_program_id},
         {"tokenInId", def_a_hex},
         {"tokenOutId", def_b_hex},
         {"config", config},
+        {"poolData", pool_data},
         {"userInputHoldingId", user_input_holding_hex},
         {"userOutputHoldingId", user_output_holding_hex},
         {"amountIn", amount_in_decimal},


### PR DESCRIPTION
Rename the swap-submission planning op for symmetry with the exact-in/exact-out split already applied to the quote ops (swap_exact_in_quote /
swap_exact_out_quote): swap_plan -> swap_exact_in_plan, SwapPlanRequest ->
SwapExactInPlanRequest, and the C export amm_swap_plan -> amm_swap_exact_in_plan (cbindgen header regenerated). The module's swapExactInput call site and trace are updated to match.