### PR TITLE
feat(modules/amm): add the add-liquidity API and quoting

### DIFF
--- a/apps/amm/qml/components/liquidity/AmmTokenAmountSurface.qml
+++ b/apps/amm/qml/components/liquidity/AmmTokenAmountSurface.qml
@@ -22,12 +22,20 @@ Rectangle {
     property Component adjustment
     property real adjustmentWidth: 0
     property real adjustmentHeight: 0
+    // Optional full-width content rendered inside the card, below the amount/token
+    // row (e.g. the create-pool account selector). Null → the card is unchanged.
+    property Component footer
+    property real footerHeight: 0
+    readonly property bool footerActive: root.footer !== null
+    property alias footerItem: footerLoader.item
 
     signal amountEdited(string value)
     signal amountEditingFinished(string value)
     signal supportingActionClicked
 
-    implicitHeight: Math.max(110, contentRow.implicitHeight + 24)
+    implicitHeight: root.footerActive
+                    ? Math.max(110, contentRow.implicitHeight + root.footerHeight + 30)
+                    : Math.max(110, contentRow.implicitHeight + 24)
     radius: 16
     color: root.muted ? root.theme.colors.panelBg : root.theme.colors.inputBg
     border.color: root.invalid
@@ -46,11 +54,16 @@ Rectangle {
     RowLayout {
         id: contentRow
 
-        anchors.fill: parent
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        // When a footer is present it takes the bottom of the card; otherwise the
+        // row fills the card exactly as before (12px inset).
+        anchors.bottom: footerLoader.top
         anchors.leftMargin: 16
         anchors.rightMargin: 16
         anchors.topMargin: 12
-        anchors.bottomMargin: 12
+        anchors.bottomMargin: root.footerActive ? 6 : 12
         spacing: 10
 
         ColumnLayout {
@@ -187,6 +200,21 @@ Rectangle {
             Layout.preferredWidth: root.accessoryWidth
             Layout.preferredHeight: root.accessoryHeight
         }
+    }
+
+    Loader {
+        id: footerLoader
+
+        active: root.footerActive
+        visible: active
+        sourceComponent: root.footer
+        height: active ? root.footerHeight : 0
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        anchors.leftMargin: 16
+        anchors.rightMargin: 16
+        anchors.bottomMargin: active ? 12 : 0
     }
 
     Behavior on color {

--- a/apps/amm/qml/components/liquidity/NewPositionForm.qml
+++ b/apps/amm/qml/components/liquidity/NewPositionForm.qml
@@ -21,6 +21,12 @@ AmmActionCard {
 
     property var newPositionContext: ({})
     property var flowState: ({})
+    // Wallet token holdings (backend.tokenHoldings()) for the create-pool account
+    // selectors, narrowed per side by the selected token's base58 definitionId. The
+    // chosen holdings feed the createPool call via submissionSnapshot().
+    property var holdings: []
+    readonly property string selectedHoldingAId: tokenAInput.selectedHoldingId
+    readonly property string selectedHoldingBId: tokenBInput.selectedHoldingId
     property string selectedTokenAId: ""
     property string selectedTokenBId: ""
     property int selectedFeeBps: 30
@@ -86,10 +92,17 @@ AmmActionCard {
                                     && root.selectedTokenBId.length > 0
                                     && root.selectedTokenAId !== root.selectedTokenBId
     readonly property bool resolvingToken: root.resolvingTokenId.length > 0
+    // Creating a pool submits caller-provided A/B holdings (see submissionSnapshot);
+    // require both selectors resolved. Add-liquidity enumerates holdings server-side,
+    // so it does not gate on these.
+    readonly property bool holdingsReady: !root.missingPool
+                                          || (root.selectedHoldingAId.length > 0
+                                              && root.selectedHoldingBId.length > 0)
     readonly property bool canConfirm: root.quotePayload.status === "ok"
                                        && root.quotePayload.canSubmit === true
                                        && root.quoteMatchesPair()
                                        && String(root.quotePayload.quoteHash || "").length > 0
+                                       && root.holdingsReady
                                        && !root.contextLoading
                                        && !root.quoteLoading
                                        && !root.quoteStale
@@ -248,6 +261,10 @@ AmmActionCard {
                 tokenData: root.tokenA.definitionId ? root.tokenA : null
                 tokens: root.tokens
                 selectedTokenId: root.selectedTokenAId
+                holdings: root.holdings
+                holdingDefinitionId: root.selectedTokenAId
+                showHoldingSelector: root.missingPool && root.hasPair
+                selectorObjectName: "newPositionAccountSelectorA"
                 tokenInvalid: root.tokenHasError("A")
                 tokenSelectionEnabled: !root.contextLoading && !root.submitting
                 adjustment: root.missingPool ? priceAmountAAdjustment : null
@@ -296,6 +313,10 @@ AmmActionCard {
                 tokenData: root.tokenB.definitionId ? root.tokenB : null
                 tokens: root.tokens
                 selectedTokenId: root.selectedTokenBId
+                holdings: root.holdings
+                holdingDefinitionId: root.selectedTokenBId
+                showHoldingSelector: root.missingPool && root.hasPair
+                selectorObjectName: "newPositionAccountSelectorB"
                 tokenInvalid: root.tokenHasError("B")
                 tokenSelectionEnabled: !root.contextLoading && !root.submitting
                 adjustment: root.missingPool ? priceAmountBAdjustment : null
@@ -1440,8 +1461,10 @@ AmmActionCard {
             // Canonical-order holdings for the create path's createPool call: the
             // request's tokenAId/amountARaw are canonical, so holdingAId must be the
             // canonical token A's holding too (createPool re-canonicalizes as a no-op).
-            "holdingAId": String((root.displayIsCanonical ? root.tokenA : root.tokenB).holdingId || ""),
-            "holdingBId": String((root.displayIsCanonical ? root.tokenB : root.tokenA).holdingId || ""),
+            // The user picks these via the per-side account selectors; selectedHoldingA
+            // is display token A's holding, so it aligns with tokenA the same way.
+            "holdingAId": String(root.displayIsCanonical ? root.selectedHoldingAId : root.selectedHoldingBId),
+            "holdingBId": String(root.displayIsCanonical ? root.selectedHoldingBId : root.selectedHoldingAId),
             "pairText": qsTr("%1 / %2").arg(root.shortTokenName(root.tokenA)).arg(root.shortTokenName(root.tokenB)),
             "feeText": root.feeLabel(root.selectedFeeBps),
             "depositAText": root.quoteAmount("actualAmountARaw", "actualAmountBRaw", "A"),

--- a/apps/amm/qml/components/liquidity/NewPositionForm.qml
+++ b/apps/amm/qml/components/liquidity/NewPositionForm.qml
@@ -597,6 +597,7 @@ AmmActionCard {
         }
 
         AmmPrimaryButton {
+            objectName: "newPositionSubmitButton"
             Layout.fillWidth: true
             Layout.minimumHeight: 56
             theme: root.theme

--- a/apps/amm/qml/components/liquidity/NewPositionForm.qml
+++ b/apps/amm/qml/components/liquidity/NewPositionForm.qml
@@ -48,7 +48,6 @@ AmmActionCard {
     readonly property bool quoteLoading: root.flowState.quoteLoading === true
     readonly property bool submitting: root.flowState.submitting === true
     readonly property bool quoteStale: root.flowState.quoteStale === true
-    readonly property bool poolCreationPending: root.flowState.poolCreationPending === true
     readonly property string submitError: root.flowState.errorCode
                                                   ? root.issueText(root.flowState.errorCode) : ""
     readonly property string transactionId: String(root.flowState.transactionId || "")
@@ -95,7 +94,11 @@ AmmActionCard {
                                        && !root.quoteLoading
                                        && !root.quoteStale
                                        && !root.submitting
-                                       && !root.poolCreationPending
+                                       // A create-pool tx for this pair is already in flight
+                                       // (transactionId set) but the pool still reads missing until
+                                       // the chain processes it — block confirm so a stale
+                                       // missing_pool quote can't submit a duplicate NewDefinition.
+                                       && !(root.missingPool && root.transactionId.length > 0)
 
     signal quoteRequested(bool immediate, var quoteRequest)
     signal confirmationRequested(var snapshot)
@@ -600,7 +603,6 @@ AmmActionCard {
             text: root.submitting
                   ? qsTr("Submitting…")
                   : root.contextLoading ? qsTr("Loading…")
-                  : root.poolCreationPending ? qsTr("Waiting for pool")
                   : root.missingPool ? qsTr("Create pool") : qsTr("Add liquidity")
             enabled: root.canConfirm
             onClicked: root.confirmationRequested(root.submissionSnapshot())
@@ -854,22 +856,6 @@ AmmActionCard {
         root.localErrors = []
         root.noteDraftChanged()
         root.requestQuote(true)
-    }
-
-    function acceptPoolActivation(quote) {
-        if (!quote || quote.status !== "ok"
-                || quote.poolStatus !== "active_pool"
-                || !root.quoteMatchesSelectedPair(quote)) {
-            return false
-        }
-        root.confirmedPoolStatus = "active_pool"
-        root.activePoolQuote = quote
-        root.amountA = ""
-        root.amountB = ""
-        root.minimumAmountARaw = ""
-        root.minimumAmountBRaw = ""
-        root.localErrors = []
-        return true
     }
 
     function noteDraftChanged() {
@@ -1449,8 +1435,12 @@ AmmActionCard {
         var built = root.buildQuoteRequest()
         return {
             "request": built.request,
-            "poolProbeRequest": root.poolProbeRequest(built.request),
             "quoteHash": String(root.quotePayload.quoteHash || ""),
+            // Canonical-order holdings for the create path's createPool call: the
+            // request's tokenAId/amountARaw are canonical, so holdingAId must be the
+            // canonical token A's holding too (createPool re-canonicalizes as a no-op).
+            "holdingAId": String((root.displayIsCanonical ? root.tokenA : root.tokenB).holdingId || ""),
+            "holdingBId": String((root.displayIsCanonical ? root.tokenB : root.tokenA).holdingId || ""),
             "pairText": qsTr("%1 / %2").arg(root.shortTokenName(root.tokenA)).arg(root.shortTokenName(root.tokenB)),
             "feeText": root.feeLabel(root.selectedFeeBps),
             "depositAText": root.quoteAmount("actualAmountARaw", "actualAmountBRaw", "A"),

--- a/apps/amm/qml/components/liquidity/TokenAmountInput.qml
+++ b/apps/amm/qml/components/liquidity/TokenAmountInput.qml
@@ -2,6 +2,8 @@ pragma ComponentBehavior: Bound
 
 import QtQuick
 
+import Logos.Wallet
+
 import "../shared"
 
 AmmTokenAmountSurface {
@@ -18,6 +20,21 @@ AmmTokenAmountSurface {
     property bool tokenSelectionEnabled: true
     property bool editPending: false
     property string pendingValue: ""
+    // Account selector (create-pool only): the wallet holdings to pick from, the
+    // token's base58 definitionId to filter by, and whether to show it at all. The
+    // chosen holding id is exposed as selectedHoldingId. Mirrors the swap card, where
+    // the selector sits inside the input card below the token button.
+    property var holdings: []
+    property string holdingDefinitionId: ""
+    property bool showHoldingSelector: false
+    // objectName forwarded to the account selector, so UI tests can pick the
+    // funding holding for this side deterministically.
+    property string selectorObjectName: ""
+    readonly property string selectedHoldingId: root.footerItem && root.footerItem.selectedAccountId
+                                                ? String(root.footerItem.selectedAccountId) : ""
+
+    footer: root.showHoldingSelector ? accountFooter : null
+    footerHeight: root.footerItem ? root.footerItem.implicitHeight : 0
     property var disabledReasonForCode: function(code) {
         return qsTr("This token is unavailable (%1).").arg(code || "unknown")
     }
@@ -63,6 +80,40 @@ AmmTokenAmountSurface {
         interval: 250
         repeat: false
         onTriggered: root.commitPendingEdit()
+    }
+
+    Component {
+        id: accountFooter
+
+        // The Loader stretches this wrapper to the card width; the selector takes the
+        // right half, right-aligned, matching the swap card's account selector.
+        Item {
+            implicitHeight: footerSelector.implicitHeight
+
+            property alias selectedAccountId: footerSelector.selectedAccountId
+
+            ProgramAccountSelector {
+                id: footerSelector
+
+                objectName: root.selectorObjectName
+                width: Math.round(parent.width / 2)
+                anchors.right: parent.right
+                anchors.top: parent.top
+                sourceModel: root.holdings
+                accountType: "TokenHolding"
+                stateField: "definitionId"
+                stateValue: root.holdingDefinitionId
+                selectionMode: ProgramAccountSelector.Input
+                showWhenSingle: true
+                textAlignment: Text.AlignRight
+                backgroundColor: root.theme.colors.panelBg
+                hoverColor: root.theme.colors.panelHoverBg
+                textColor: root.theme.colors.textPrimary
+                secondaryTextColor: root.theme.colors.textSecondary
+                borderColor: root.theme.colors.borderStrong
+                focusColor: root.theme.colors.ctaBg
+            }
+        }
     }
 
     Component {

--- a/apps/amm/qml/components/swap/SwapCard.qml
+++ b/apps/amm/qml/components/swap/SwapCard.qml
@@ -533,6 +533,7 @@ Rectangle {
             label: "Sell"
             inputObjectName: "swapSellInput"
             buttonObjectName: "swapSellTokenButton"
+            selectorObjectName: "swapSellAccountSelector"
             amount: root.sellDisplay
             token: root.sellToken
             holdings: root.holdings
@@ -595,6 +596,7 @@ Rectangle {
             label: "Buy"
             inputObjectName: "swapBuyInput"
             buttonObjectName: "swapBuyTokenButton"
+            selectorObjectName: "swapBuyAccountSelector"
             amount: root.buyDisplay
             token: root.buyToken
             holdings: root.holdings

--- a/apps/amm/qml/components/swap/SwapCard.qml
+++ b/apps/amm/qml/components/swap/SwapCard.qml
@@ -17,6 +17,12 @@ Rectangle {
     // Real backend replica (logos.module("amm_ui")), wired from SwapPage.
     property var backend: null
 
+    // The wallet's token holdings (backend.tokenHoldings()), fed to each slot's
+    // account selector; the chosen input/output holding ids drive the submit.
+    property var holdings: []
+    readonly property string sellHolding: sellTokenInput.selectedHoldingId
+    readonly property string buyHolding: buyTokenInput.selectedHoldingId
+
     property var sellToken: null
     property var buyToken: null
     property string sellInput: ""
@@ -389,6 +395,10 @@ Rectangle {
                                        && root.poolResolved && root.poolExists
                                        && !outputExceedsLiquidity && !root.swapInProgress
                                        && !root.quoteLoading && root.walletOpen
+                                       // Both holdings must be chosen (auto-selected
+                                       // when the wallet has exactly one per token).
+                                       && root.sellHolding.length > 0
+                                       && root.buyHolding.length > 0
 
     readonly property string submitButtonText: {
         if (!tokensSelected) return qsTr("Select tokens")
@@ -400,6 +410,8 @@ Rectangle {
         if (outputExceedsLiquidity) return qsTr("Insufficient liquidity")
         if (parsedSellAmount <= 0 || parsedBuyAmount <= 0) return qsTr("Amount too small")
         if (!root.walletOpen) return qsTr("Connect wallet to swap")
+        if (root.sellHolding.length === 0 || root.buyHolding.length === 0)
+            return qsTr("Select token accounts")
         return qsTr("Swap")
     }
 
@@ -460,8 +472,9 @@ Rectangle {
         var deadline = "18446744073709551615"
         var inDef = root.sellToken.definitionId
         var outDef = root.buyToken.definitionId
-        var inHolding = root.sellToken.holding
-        var outHolding = root.buyToken.holding
+        // Holdings come from the per-slot account selector, not the token config.
+        var inHolding = root.sellHolding
+        var outHolding = root.buyHolding
 
         // The on-chain guard is the quote's exact-integer bound: the exact-input
         // floor (minReceivedRaw) or the exact-output ceiling (maxInRaw). The typed
@@ -514,6 +527,7 @@ Rectangle {
         spacing: 0
 
         TokenInput {
+            id: sellTokenInput
             Layout.fillWidth: true
             theme: root.theme
             label: "Sell"
@@ -521,6 +535,7 @@ Rectangle {
             buttonObjectName: "swapSellTokenButton"
             amount: root.sellDisplay
             token: root.sellToken
+            holdings: root.holdings
             active: root.editingSide === "sell"
             // Sell amount is sent to the backend as a raw base-units integer
             // string; reject fractional entry rather than fail opaquely.
@@ -574,6 +589,7 @@ Rectangle {
         }
 
         TokenInput {
+            id: buyTokenInput
             Layout.fillWidth: true
             theme: root.theme
             label: "Buy"
@@ -581,6 +597,7 @@ Rectangle {
             buttonObjectName: "swapBuyTokenButton"
             amount: root.buyDisplay
             token: root.buyToken
+            holdings: root.holdings
             active: root.editingSide === "buy"
             // Exact-output amount is sent to the backend as a raw base-units
             // integer string; reject fractional entry rather than fail opaquely.

--- a/apps/amm/qml/components/swap/TokenInput.qml
+++ b/apps/amm/qml/components/swap/TokenInput.qml
@@ -28,6 +28,9 @@ Rectangle {
     // objectName forwarded to the token-select button, so tests can open the
     // right picker by objectId rather than fuzzy text.
     property alias buttonObjectName: tokenButton.objectName
+    // objectName forwarded to the account selector, so tests can pick the funding
+    // holding for this side deterministically.
+    property alias selectorObjectName: accountSelector.objectName
 
     signal tokenClicked()
     signal inputEdited(string newValue)

--- a/apps/amm/qml/components/swap/TokenInput.qml
+++ b/apps/amm/qml/components/swap/TokenInput.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
+import Logos.Wallet
 import "TokenVisuals.js" as TokenVisuals
 
 Rectangle {
@@ -10,6 +11,11 @@ Rectangle {
     property string amount: ""
     property string usdValue: ""
     property var token: null
+    // The wallet's token holdings (backend.tokenHoldings()); the selector narrows
+    // them to this slot's token. The chosen holding id is exposed as selectedHoldingId.
+    property var holdings: []
+    readonly property string tokenDefinitionIdHex: root.token ? String(root.token.definitionId || "") : ""
+    readonly property string selectedHoldingId: accountSelector.selectedAccountId
     property bool active: true
     // When true, restrict input to digits only — used for the sell-amount
     // field, whose value is sent to the backend as a raw base-units integer
@@ -34,123 +40,160 @@ Rectangle {
 
     radius: 16
     color: root.active ? theme.colors.inputBg : theme.colors.panelBg
-    implicitHeight: 110
+    // Height grows with the content: the amount/token row plus the full-width
+    // account selector below it (34/20/0px depending on how many holdings match).
+    implicitHeight: tiContent.implicitHeight + 28
 
     Behavior on color { ColorAnimation { duration: 300 } }
 
-    RowLayout {
-        anchors.fill: parent
+    ColumnLayout {
+        id: tiContent
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
         anchors.leftMargin: 16
         anchors.rightMargin: 16
         anchors.topMargin: 14
-        anchors.bottomMargin: 14
-        spacing: 8
+        spacing: 10
 
-        ColumnLayout {
+        RowLayout {
             Layout.fillWidth: true
-            spacing: 4
+            spacing: 8
 
-            Text {
-                text: root.label
-                color: theme.colors.textSecondary
-                font.pixelSize: 14
-            }
-
-            Item {
+            ColumnLayout {
                 Layout.fillWidth: true
-                height: 44
+                spacing: 4
 
-                TextInput {
-                    id: tiInput
-                    anchors.fill: parent
-                    color: root.active ? theme.colors.textPrimary : theme.colors.textSecondary
-                    font.pixelSize: 36
-                    font.weight: Font.Bold
-                    selectionColor: theme.colors.selection
-                    clip: true
-                    onTextEdited: {
-                        if (root.digitsOnly) {
-                            // Amounts are base units (integers) — strip any
-                            // character that slips past the validator (e.g.
-                            // via paste) before it reaches the backend.
-                            var filtered = text.replace(/[^0-9]/g, "")
-                            if (filtered !== text)
-                                text = filtered // does not re-trigger onTextEdited
-                            root.inputEdited(filtered)
-                        } else {
-                            root.inputEdited(text)
+                Text {
+                    text: root.label
+                    color: theme.colors.textSecondary
+                    font.pixelSize: 14
+                }
+
+                Item {
+                    Layout.fillWidth: true
+                    height: 44
+
+                    TextInput {
+                        id: tiInput
+                        anchors.fill: parent
+                        color: root.active ? theme.colors.textPrimary : theme.colors.textSecondary
+                        font.pixelSize: 36
+                        font.weight: Font.Bold
+                        selectionColor: theme.colors.selection
+                        clip: true
+                        onTextEdited: {
+                            if (root.digitsOnly) {
+                                // Amounts are base units (integers) — strip any
+                                // character that slips past the validator (e.g.
+                                // via paste) before it reaches the backend.
+                                var filtered = text.replace(/[^0-9]/g, "")
+                                if (filtered !== text)
+                                    text = filtered // does not re-trigger onTextEdited
+                                root.inputEdited(filtered)
+                            } else {
+                                root.inputEdited(text)
+                            }
+                        }
+                        validator: RegularExpressionValidator {
+                            regularExpression: root.digitsOnly ? /^[0-9]*$/ : /^[0-9]*\.?[0-9]*$/
                         }
                     }
-                    validator: RegularExpressionValidator {
-                        regularExpression: root.digitsOnly ? /^[0-9]*$/ : /^[0-9]*\.?[0-9]*$/
+
+                    Text {
+                        anchors.fill: parent
+                        text: "0"
+                        color: theme.colors.textPlaceholder
+                        font: tiInput.font
+                        visible: tiInput.text === "" && !tiInput.activeFocus
+                        verticalAlignment: Text.AlignVCenter
                     }
                 }
 
                 Text {
-                    anchors.fill: parent
-                    text: "0"
-                    color: theme.colors.textPlaceholder
-                    font: tiInput.font
-                    visible: tiInput.text === "" && !tiInput.activeFocus
-                    verticalAlignment: Text.AlignVCenter
+                    text: root.usdValue
+                    color: theme.colors.textSecondary
+                    font.pixelSize: 13
+                    visible: root.usdValue !== ""
                 }
             }
 
-            Text {
-                text: root.usdValue
-                color: theme.colors.textSecondary
-                font.pixelSize: 13
-                visible: root.usdValue !== ""
+            Rectangle {
+                id: tokenButton
+                Layout.alignment: Qt.AlignVCenter
+                height: 40
+                radius: 20
+                color: tokenBtnHover.containsMouse ? theme.colors.panelHoverBg : theme.colors.panelBg
+                implicitWidth: tokenBtnRow.implicitWidth + 24
+                Behavior on color { ColorAnimation { duration: 120 } }
+
+                RowLayout {
+                    id: tokenBtnRow
+                    anchors.centerIn: parent
+                    spacing: 6
+
+                    Rectangle {
+                        width: 24; height: 24; radius: 12
+                        color: root.token ? TokenVisuals.colorFor(root.token.symbol) : theme.colors.noTokenCircle
+                        visible: root.token !== null
+                        Text {
+                            anchors.centerIn: parent
+                            text: root.token ? TokenVisuals.letterFor(root.token.symbol) : ""
+                            color: "#ffffff"
+                            font.pixelSize: 10
+                            font.weight: Font.Bold
+                        }
+                    }
+
+                    Text {
+                        text: root.token ? root.token.symbol : "Select token"
+                        color: theme.colors.textPrimary
+                        font.pixelSize: 15
+                        font.weight: root.token ? Font.Medium : Font.Normal
+                    }
+
+                    Text {
+                        text: "▼"
+                        color: theme.colors.textSecondary
+                        font.pixelSize: 10
+                    }
+                }
+
+                MouseArea {
+                    id: tokenBtnHover
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: root.tokenClicked()
+                }
             }
         }
 
-        Rectangle {
-            id: tokenButton
-            height: 40
-            radius: 20
-            color: tokenBtnHover.containsMouse ? theme.colors.panelHoverBg : theme.colors.panelBg
-            implicitWidth: tokenBtnRow.implicitWidth + 24
-            Behavior on color { ColorAnimation { duration: 120 } }
-
-            RowLayout {
-                id: tokenBtnRow
-                anchors.centerIn: parent
-                spacing: 6
-
-                Rectangle {
-                    width: 24; height: 24; radius: 12
-                    color: root.token ? TokenVisuals.colorFor(root.token.symbol) : theme.colors.noTokenCircle
-                    visible: root.token !== null
-                    Text {
-                        anchors.centerIn: parent
-                        text: root.token ? TokenVisuals.letterFor(root.token.symbol) : ""
-                        color: "#ffffff"
-                        font.pixelSize: 10
-                        font.weight: Font.Bold
-                    }
-                }
-
-                Text {
-                    text: root.token ? root.token.symbol : "Select token"
-                    color: theme.colors.textPrimary
-                    font.pixelSize: 15
-                    font.weight: root.token ? Font.Medium : Font.Normal
-                }
-
-                Text {
-                    text: "▼"
-                    color: theme.colors.textSecondary
-                    font.pixelSize: 10
-                }
-            }
-
-            MouseArea {
-                id: tokenBtnHover
-                anchors.fill: parent
-                hoverEnabled: true
-                cursorShape: Qt.PointingHandCursor
-                onClicked: root.tokenClicked()
-            }
+        // Which of the user's holdings for this token to use, full width below the
+        // amount/token row. Always shown when there is at least one holding
+        // (auto-selecting the single one); "No funds" when there are none.
+        ProgramAccountSelector {
+            id: accountSelector
+            // Half width, pinned to the right edge under the token button.
+            Layout.alignment: Qt.AlignRight
+            Layout.preferredWidth: Math.round(tiContent.width / 2)
+            sourceModel: root.holdings
+            accountType: "TokenHolding"
+            // The swap view is hex end-to-end: the token's definitionId is hex, so match the
+            // holding's hex definitionIdHex (tokenHoldings emits both — `definitionId` is base58
+            // for the liquidity view). Filtering on `definitionId` here never matches a hex
+            // stateValue, so every token would show "No funds".
+            stateField: "definitionIdHex"
+            stateValue: root.tokenDefinitionIdHex
+            selectionMode: ProgramAccountSelector.Input
+            showWhenSingle: true
+            textAlignment: Text.AlignRight
+            backgroundColor: root.theme.colors.panelBg
+            hoverColor: root.theme.colors.panelHoverBg
+            textColor: root.theme.colors.textPrimary
+            secondaryTextColor: root.theme.colors.textSecondary
+            borderColor: root.theme.colors.borderStrong
+            focusColor: root.theme.colors.ctaBg
         }
     }
 }

--- a/apps/amm/qml/pages/LiquidityPage.qml
+++ b/apps/amm/qml/pages/LiquidityPage.qml
@@ -248,10 +248,6 @@ Item {
             form.failTokenResolution(code)
         }
 
-        function onPoolActivated(quote) {
-            form.acceptPoolActivation(quote)
-        }
-
         function onQuoteRefreshRequested(immediate) {
             form.requestQuote(immediate)
         }

--- a/apps/amm/qml/pages/LiquidityPage.qml
+++ b/apps/amm/qml/pages/LiquidityPage.qml
@@ -17,6 +17,27 @@ Item {
     property var runtime: null
     readonly property NewPositionFlow flow: newPositionFlow
 
+    // Wallet token holdings (backend.tokenHoldings()) feeding the create-pool
+    // account selectors; refetched when the wallet opens.
+    property var holdings: []
+
+    function refreshHoldings() {
+        if (!root.backend || root.runtime === null)
+            return
+        root.runtime.watch(root.backend.tokenHoldings(),
+            function(list) { root.holdings = list },
+            function(err) { console.warn("tokenHoldings error:", err) })
+    }
+
+onBackendChanged: root.refreshHoldings()
+    onRuntimeChanged: root.refreshHoldings()
+    Component.onCompleted: root.refreshHoldings()
+
+    Connections {
+        target: root.backend
+        function onIsWalletOpenChanged() { root.refreshHoldings() }
+    }
+
     readonly property int pageMargin: width < 640 ? 16 : 24
     readonly property int contentMaxWidth: 1200
     readonly property bool wideLayout: width >= 760
@@ -215,6 +236,7 @@ Item {
                                    ? qsTr("Specify the token amounts for your liquidity contribution.")
                                    : qsTr("Choose two tokens and a fee tier for this position.")
                     showRefreshAction: false
+                    holdings: root.holdings
                     newPositionContext: newPositionFlow.newPositionContext
                     flowState: newPositionFlow.viewState
 

--- a/apps/amm/qml/pages/LiquidityPage.qml
+++ b/apps/amm/qml/pages/LiquidityPage.qml
@@ -262,6 +262,7 @@ Item {
     TransactionConfirmationDialog {
         id: confirmationDialog
 
+        objectName: "liquidityConfirmDialog"
         title: qsTr("Confirm new position")
         confirmText: qsTr("Submit")
         busy: newPositionFlow.submitting

--- a/apps/amm/qml/pages/SwapPage.qml
+++ b/apps/amm/qml/pages/SwapPage.qml
@@ -17,12 +17,46 @@ Item {
     // until the backend is ready and the call resolves.
     property var tokens: []
 
+    // The wallet's token holdings (backend.tokenHoldings()), fed to the swap card's
+    // account selectors. Refetched when the wallet opens (it needs an open wallet).
+    property var holdings: []
+
+    // Monotonic tag for refreshHoldings() requests: a callback applies only if it is still the
+    // latest, so an out-of-order tokenHoldings reply can't clobber the current wallet's list.
+    property int holdingsGeneration: 0
+
+    function refreshHoldings() {
+        if (!root.backend)
+            return
+        // onBackendChanged and onIsWalletOpenChanged can start overlapping tokenHoldings
+        // requests (a wallet-open refresh racing a just-closed one, or a fast wallet switch)
+        // whose replies may arrive out of order. Tag each request and drop any callback a newer
+        // request has superseded, so a stale (empty, or previous-wallet) list can't overwrite
+        // the current holdings.
+        const generation = ++root.holdingsGeneration
+        logos.watch(root.backend.tokenHoldings(),
+            function(list) {
+                if (generation === root.holdingsGeneration)
+                    root.holdings = list
+            },
+            function(err) {
+                if (generation === root.holdingsGeneration)
+                    console.warn("tokenHoldings error:", err)
+            })
+    }
+
     onBackendChanged: {
         if (root.backend) {
             logos.watch(root.backend.tokenList(),
                 function(list) { root.tokens = list },
                 function(err) { console.warn("tokenList error:", err) })
+            root.refreshHoldings()
         }
+    }
+
+    Connections {
+        target: root.backend
+        function onIsWalletOpenChanged() { root.refreshHoldings() }
     }
 
     QtObject {
@@ -104,6 +138,7 @@ Item {
                 Layout.alignment: Qt.AlignHCenter
                 theme: pageTheme
                 tokens: root.tokens
+                holdings: root.holdings
                 backend: root.backend
                 width: Math.min(480, root.width - 32)
 

--- a/apps/amm/qml/state/NewPositionFlow.qml
+++ b/apps/amm/qml/state/NewPositionFlow.qml
@@ -20,7 +20,6 @@ QtObject {
         "quoteLoading": root.quoteLoading,
         "quoteStale": root.quoteStale,
         "submitting": root.submitting,
-        "poolCreationPending": root.selectedPoolCreationPending(),
         "transactionId": root.transactionId,
         "errorCode": root.flowErrorCode || root.contextErrorCode
                      || root.quoteErrorCode
@@ -39,12 +38,9 @@ QtObject {
     property string contextErrorCode: ""
     property string quoteErrorCode: ""
     property var pendingQuoteRequest: ({ "ok": false, "request": ({}) })
-    property var pendingPoolProbes: []
-    property bool poolProbeInFlight: false
 
     signal tokenResolutionFinished(bool finalResponse)
     signal tokenResolutionFailed(string code)
-    signal poolActivated(var quote)
     signal quoteRefreshRequested(bool immediate)
     signal submitSucceeded
     signal submitFailed
@@ -55,13 +51,6 @@ QtObject {
         interval: 250
         repeat: false
         onTriggered: root.requestQuoteNow(root.quoteSerial)
-    }
-
-    property Timer poolPoller: Timer {
-        interval: 5000
-        repeat: true
-        running: root.pendingPoolProbes.length > 0
-        onTriggered: root.pollPendingPool()
     }
 
     onNewPositionContextChanged: root.invalidateQuote()
@@ -207,13 +196,19 @@ QtObject {
             return
         }
 
+        // Pool creation (initialPriceRealRaw is set only on the missing-pool path) goes
+        // through the new createPool op — hex ids, caller-provided accounts. Add-liquidity
+        // keeps the legacy submitNewPosition.
+        if (snapshot.request.initialPriceRealRaw !== undefined) {
+            root.createPool(snapshot)
+            return
+        }
+
         root.runtime.watch(root.backend.submitNewPosition(snapshot.request, snapshot.quoteHash),
             function(result) {
                 if (result && result.status === "submitted"
                         && /^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(
                             String(result.transactionId || ""))) {
-                    if (snapshot.request.initialPriceRealRaw !== undefined)
-                        root.watchPoolCreation(snapshot.poolProbeRequest, result.deadlineMs)
                     root.submitting = false
                     root.transactionId = result.transactionId
                     root.flowErrorCode = ""
@@ -224,6 +219,58 @@ QtObject {
                     return
                 }
                 root.finishSubmitFailure(result || root.quoteError("wallet_submission_failed"))
+            },
+            function(error) {
+                root.finishSubmitFailure(root.quoteError("wallet_submission_failed"))
+            })
+    }
+
+    // Create a pool via the new createPool op. A new pool has no pre-existing LP
+    // holding, so the caller provides a fresh account: create one, then submit. No
+    // confirmation poll yet (transactionStatus is pending an upstream dependency).
+    function createPool(snapshot) {
+        root.runtime.watch(root.backend.createAccountPublic(),
+            function(lpId) {
+                if (!lpId || String(lpId).length === 0) {
+                    root.finishSubmitFailure(root.quoteError("wallet_submission_failed"))
+                    return
+                }
+                root.submitCreatePool(snapshot, String(lpId))
+            },
+            function(error) {
+                root.finishSubmitFailure(root.quoteError("wallet_submission_failed"))
+            })
+    }
+
+    function submitCreatePool(snapshot, lpHoldingId) {
+        var request = {
+            "tokenAId": snapshot.request.tokenAId,
+            "tokenBId": snapshot.request.tokenBId,
+            "holdingAId": snapshot.holdingAId,
+            "holdingBId": snapshot.holdingBId,
+            "lpHoldingId": lpHoldingId,
+            "amountARaw": snapshot.request.amountARaw,
+            "amountBRaw": snapshot.request.amountBRaw,
+            "feeBps": snapshot.request.feeBps,
+            // u64-max sentinel = no deadline, same as the swap submits.
+            "deadlineMs": "18446744073709551615"
+        }
+        root.runtime.watch(root.backend.createPool(request),
+            function(result) {
+                if (result && result.status === "ok"
+                        && String(result.transactionId || "").length > 0) {
+                    root.submitting = false
+                    root.transactionId = String(result.transactionId)
+                    root.flowErrorCode = ""
+                    root.contextErrorCode = ""
+                    root.quoteErrorCode = ""
+                    root.invalidateQuote()
+                    root.submitSucceeded()
+                    return
+                }
+                var code = result && result.error ? String(result.error)
+                                                  : "wallet_submission_failed"
+                root.finishSubmitFailure(root.quoteError(code))
             },
             function(error) {
                 root.finishSubmitFailure(root.quoteError("wallet_submission_failed"))
@@ -245,89 +292,6 @@ QtObject {
         if (hasFreshQuote)
             return
         root.scheduleQuote(true, root.pendingQuoteRequest)
-    }
-
-    function watchPoolCreation(request, deadlineMs) {
-        const key = root.pairKey(request)
-        let deadline = Number(deadlineMs)
-        if (!isFinite(deadline) || deadline <= 0)
-            deadline = 0
-        const pending = root.pendingPoolProbes.filter(function(item) {
-            return item.key !== key
-        })
-        pending.push({
-            "key": key,
-            "request": request,
-            "deadlineMs": deadline
-        })
-        root.pendingPoolProbes = pending
-        Qt.callLater(root.pollPendingPool)
-    }
-
-    function pollPendingPool() {
-        if (root.poolProbeInFlight || root.pendingPoolProbes.length === 0
-                || !root.walletStateReady || root.runtime === null) {
-            return
-        }
-        const pending = root.pendingPoolProbes[0]
-        root.poolProbeInFlight = true
-        root.runtime.watch(root.backend.quoteNewPosition(pending.request),
-            function(quote) {
-                root.finishPoolProbe(pending, quote)
-            },
-            function(error) {
-                root.finishPoolProbe(pending, null)
-            })
-    }
-
-    function finishPoolProbe(pending, quote) {
-        root.poolProbeInFlight = false
-        if (quote && quote.poolStatus === "active_pool") {
-            root.removePendingPool(pending.key)
-            if (root.matchesSelectedPair(pending.request)) {
-                root.poolActivated(quote)
-                root.invalidateQuote()
-                root.refreshContext(true)
-            }
-            return
-        }
-        if (pending.deadlineMs > 0 && Date.now() >= pending.deadlineMs) {
-            root.removePendingPool(pending.key)
-            return
-        }
-        root.rotatePendingPool()
-    }
-
-    function pairKey(request) {
-        return String(request.tokenAId || "") + ":" + String(request.tokenBId || "")
-    }
-
-    function matchesSelectedPair(request) {
-        return root.pairKey(root.pendingQuoteRequest.request || {}) === root.pairKey(request)
-    }
-
-    function selectedPoolCreationPending() {
-        const request = root.pendingQuoteRequest.request || {}
-        if (!request.tokenAId || !request.tokenBId)
-            return false
-        const selected = root.pairKey(request)
-        return root.pendingPoolProbes.some(function(item) {
-            return item.key === selected
-        })
-    }
-
-    function removePendingPool(key) {
-        root.pendingPoolProbes = root.pendingPoolProbes.filter(function(item) {
-            return item.key !== key
-        })
-    }
-
-    function rotatePendingPool() {
-        if (root.pendingPoolProbes.length < 2)
-            return
-        const pending = root.pendingPoolProbes.slice(1)
-        pending.push(root.pendingPoolProbes[0])
-        root.pendingPoolProbes = pending
     }
 
     function draftChanged() {

--- a/apps/amm/src/AmmUiBackend.cpp
+++ b/apps/amm/src/AmmUiBackend.cpp
@@ -279,6 +279,13 @@ QVariantMap AmmUiBackend::liquidityQuote(QVariantMap request)
     return m_logos->amm_module.liquidityQuote(request);
 }
 
+QVariantList AmmUiBackend::tokenHoldings()
+{
+    // Read-only list of the wallet's token holdings for the account selector. Gated
+    // by this app's wallet-open state (a closed wallet has nothing to list).
+    return m_logos->amm_module.tokenHoldings(isWalletOpen());
+}
+
 QVariantMap AmmUiBackend::createPool(QVariantMap request)
 {
     // Same connected-state submit guard as the swaps — this app's lock is

--- a/apps/amm/src/AmmUiBackend.cpp
+++ b/apps/amm/src/AmmUiBackend.cpp
@@ -271,3 +271,30 @@ QVariantList AmmUiBackend::tokenList()
 {
     return m_logos->amm_module.tokenList();
 }
+
+QVariantMap AmmUiBackend::liquidityQuote(QVariantMap request)
+{
+    // Read-only create-pool preview — no wallet guard. The module prices the opening
+    // LP and price server-side from the two deposit amounts.
+    return m_logos->amm_module.liquidityQuote(request);
+}
+
+QVariantMap AmmUiBackend::createPool(QVariantMap request)
+{
+    // Same connected-state submit guard as the swaps — this app's lock is
+    // authoritative even though the shared wallet may remain open elsewhere.
+    if (!isWalletOpen())
+        return QVariantMap {
+            { QStringLiteral("status"), QStringLiteral("error") },
+            { QStringLiteral("error"), QStringLiteral("wallet_unavailable") },
+        };
+
+    // The caller supplies the fresh LP holding in the request; the backend forwards to
+    // the module (it creates no wallet accounts) and refreshes balances on a successful
+    // submit.
+    const QVariantMap result = m_logos->amm_module.createPool(request);
+    if (result.value(QStringLiteral("status")).toString() == QStringLiteral("ok")
+        && !result.value(QStringLiteral("transactionId")).toString().isEmpty())
+        refreshBalances();
+    return result;
+}

--- a/apps/amm/src/AmmUiBackend.h
+++ b/apps/amm/src/AmmUiBackend.h
@@ -77,6 +77,8 @@ public slots:
     // accounts here.
     QVariantMap liquidityQuote(QVariantMap request) override;
     QVariantMap createPool(QVariantMap request) override;
+    // Lists the wallet's fungible token holdings for the account selector.
+    QVariantList tokenHoldings() override;
 
 private:
     void syncWalletState();

--- a/apps/amm/src/AmmUiBackend.h
+++ b/apps/amm/src/AmmUiBackend.h
@@ -71,6 +71,12 @@ public slots:
     // Reads the token list from TOKENS_CONFIG (via the module) so the Swap UI's
     // token picker is config-driven instead of hardcoded.
     QVariantList tokenList() override;
+    // Create-pool preview (liquidityQuote, read-only) and submit (createPool). The caller
+    // supplies lpHoldingId in the request — a fresh account it created via
+    // createAccountPublic() — so createPool forwards to the module and creates no wallet
+    // accounts here.
+    QVariantMap liquidityQuote(QVariantMap request) override;
+    QVariantMap createPool(QVariantMap request) override;
 
 private:
     void syncWalletState();

--- a/apps/amm/src/AmmUiBackend.rep
+++ b/apps/amm/src/AmmUiBackend.rep
@@ -114,4 +114,9 @@ class AmmUiBackend
     // invalid_account_id, bad_amount, bad_fee_bps_amount, invalid_fee_tier,
     // wallet_submission_failed, backend_error).
     SLOT(QVariantMap createPool(QVariantMap request))
+    // Lists the connected wallet's fungible token holdings for the account
+    // selector: [{ accountId, accountType:"TokenHolding", definitionId,
+    // definitionIdHex, balanceRaw }] — one row per holding account, every token,
+    // including zero-balance holdings. The selector narrows to a token by id.
+    SLOT(QVariantList tokenHoldings())
 }

--- a/apps/amm/src/AmmUiBackend.rep
+++ b/apps/amm/src/AmmUiBackend.rep
@@ -92,4 +92,26 @@ class AmmUiBackend
     // a QVariantList of QVariantMap entries. Returns an empty list if
     // TOKENS_CONFIG is unset/unreadable/invalid.
     SLOT(QVariantList tokenList())
+
+    // Server-side create-pool preview from the two deposit amounts. `request`
+    // carries { tokenAId, tokenBId, amountARaw, amountBRaw } (ids hex or base58;
+    // amounts decimal-string base units). Returns { status:"ok", error:"",
+    // amountARaw, amountBRaw, expectedLpRaw, lockedLpRaw, initialPriceRaw } — the
+    // LP the creator receives and the opening price, via the shared on-chain math.
+    // On failure { status:"error", error:<code> } — invalid_token_id,
+    // same_token_pair, amount_too_low, amount_required, bad_amount, backend_error.
+    // Read-only, no submission (the fee is not needed — it isn't part of the pool
+    // PDA nor the pricing).
+    SLOT(QVariantMap liquidityQuote(QVariantMap request))
+    // Submits a NewDefinition transaction creating the pool for the request's pair.
+    // `request` carries { tokenAId, tokenBId, holdingAId, holdingBId, lpHoldingId,
+    // amountARaw, amountBRaw, feeBps, deadlineMs } (ids hex or base58; amounts/deadline
+    // decimal strings). A new pool has no existing LP holding, so the caller supplies
+    // lpHoldingId — a fresh account it created via createAccountPublic(); the backend
+    // just forwards to the module and creates no wallet accounts here. Returns
+    // { status:"ok", error:"", transactionId:<hex tx hash> } on success, else
+    // { status:"error", error:<code> } (wallet_unavailable, config_missing,
+    // invalid_account_id, bad_amount, bad_fee_bps_amount, invalid_fee_tier,
+    // wallet_submission_failed, backend_error).
+    SLOT(QVariantMap createPool(QVariantMap request))
 }

--- a/apps/amm/tests/README.md
+++ b/apps/amm/tests/README.md
@@ -1,10 +1,14 @@
 # AMM UI tests
 
-UI-driven tests for the AMM app. `swap.mjs` drives the running app through the
-QML inspector (framework from
-[`logos-co/logos-qt-mcp`](https://github.com/logos-co/logos-qt-mcp)): it selects
-two tokens, enters an amount, submits a swap, and verifies the pool reserves
-changed **on-chain**.
+UI-driven tests for the AMM app, driving the running app through the QML
+inspector (framework from
+[`logos-co/logos-qt-mcp`](https://github.com/logos-co/logos-qt-mcp)):
+
+- `swap.mjs` selects two tokens, enters an amount, submits a swap, and verifies
+  the **A/B** pool reserves changed **on-chain**.
+- `create-pool.mjs` selects the **A/C** pair (which the setup script leaves
+  unseeded — only A/B is created), submits a pool creation, and verifies the A/C
+  pool now exists **on-chain**.
 
 ## Isolation
 
@@ -40,8 +44,9 @@ LEE_WALLET_HOME_DIR=$(pwd)/apps/amm/tests/testnet/.wallet \
   TOKENS_CONFIG=$(pwd)/apps/amm/tests/testnet/amm-tokens.json \
   nix run .#amm-ui
 
-# 3. Terminal 2 — drive the swap test; watch it click through the live UI.
-node apps/amm/tests/swap.mjs
+# 3. Terminal 2 — drive a test; watch it click through the live UI.
+node apps/amm/tests/swap.mjs         # swap against the seeded A/B pool
+node apps/amm/tests/create-pool.mjs  # create the (unseeded) A/C pool
 ```
 
 Headless CI variant (no window, launches the app itself, pass/fail only):
@@ -71,6 +76,8 @@ nix build .#integration-test -L
 
 ## Files
 
-- `swap.mjs` — the end-to-end swap UI test.
-- `testnet/setup-amm-testnet.sh` — isolated testnet + wallet bootstrap.
+- `swap.mjs` — the end-to-end swap UI test (A/B pool).
+- `create-pool.mjs` — the end-to-end create-pool UI test (creates the A/C pool).
+- `testnet/setup-amm-testnet.sh` — isolated testnet + wallet bootstrap (TKA/TKB/TKC,
+  seeds the A/B pool only).
 - `qml/`, `cpp/` — the module's own QML/C++ unit tests.

--- a/apps/amm/tests/create-pool.mjs
+++ b/apps/amm/tests/create-pool.mjs
@@ -63,7 +63,32 @@ async function formState(app, formId) {
     amountB: get("amountB"),
     submitError: get("submitError"),
     transactionId: get("transactionId"),
+    selectedHoldingAId: get("selectedHoldingAId"),
+    selectedHoldingBId: get("selectedHoldingBId"),
   };
+}
+
+// Pick the funding account for a create-pool side. The selector auto-selects a
+// single holding, but choose it explicitly (robust to multi-account wallets):
+// wait for the holdings to populate, then select the first match. canConfirm now
+// requires both A/B holdings before a pool can be created.
+async function selectAccount(app, selectorObjectName) {
+  // The selector lives in a Loader that instantiates only once the pool is known
+  // to be missing, so it may render a frame after missingPool flips — wait for it.
+  let id;
+  await app.waitFor(
+    async () => { id = await idByObjectName(app, selectorObjectName); },
+    { timeout: 10000, interval: 300, description: `${selectorObjectName} to render` },
+  );
+  await app.waitFor(
+    async () => { if ((await prop(app, id, "hasFunds")) !== true) throw new Error("no matching holdings yet"); },
+    { timeout: 10000, interval: 300, description: `${selectorObjectName} holdings to load` },
+  );
+  await evaluate(app, id, "setSelection(accountIdFor(matchingAccounts[0]), false)");
+  await app.waitFor(
+    async () => { if (!(await prop(app, id, "selectedAccountId"))) throw new Error("holding not selected yet"); },
+    { timeout: 5000, interval: 200, description: `${selectorObjectName} holding selected` },
+  );
 }
 
 async function saveShot(app, name) {
@@ -154,13 +179,24 @@ test("amm liquidity: create the A/C pool", async (app) => {
   );
   await evaluate(app, formId, "requestQuote(true)");
 
-  // 3. Wait for a submittable create quote (missing pool + funded minimum deposit).
+  // 3. Wait for the missing-pool quote (which makes the per-side account selectors
+  //    render), pick the funding account for each side, then wait for a submittable
+  //    create quote — canConfirm needs the funded minimum deposit AND both holdings.
   try {
     await app.waitFor(
       async () => {
         const s = await formState(app, formId);
         if (s.poolStatus === "active_pool")
           throw new Error("A/C pool already exists — reset the testnet (only A/B should be seeded)");
+        if (!s.missingPool) throw new Error("pool status not resolved yet");
+      },
+      { timeout: 20000, interval: 500, description: "missing-pool quote" },
+    );
+    await selectAccount(app, "newPositionAccountSelectorA");
+    await selectAccount(app, "newPositionAccountSelectorB");
+    await app.waitFor(
+      async () => {
+        const s = await formState(app, formId);
         if (!s.canConfirm) throw new Error("create CTA not ready yet");
       },
       { timeout: 20000, interval: 500, description: "create CTA ready" },

--- a/apps/amm/tests/create-pool.mjs
+++ b/apps/amm/tests/create-pool.mjs
@@ -1,0 +1,273 @@
+// ---------------------------------------------------------------------------
+// AMM UI test — create a NEW pool (A/C) through the Liquidity view.
+//
+// Drives the running AMM UI through the QML inspector (logos-qt-mcp), the same
+// way swap.mjs does. It selects the A/C pair (which the setup script leaves
+// UNSEEDED — only A/B is created), lets the form auto-fill the minimum opening
+// deposit, submits the create, and verifies the pool now exists ON-CHAIN.
+//
+// Prereqs in the running app (see apps/amm/tests/README.md):
+//   * launched against the isolated test wallet + TOKENS_CONFIG that
+//     testnet/setup-amm-testnet.sh writes (TKA, TKB, TKC)
+//   * an open wallet + reachable local sequencer
+//   * the A/C pool must NOT exist yet (setup only seeds A/B)
+// ---------------------------------------------------------------------------
+
+import { resolve } from "node:path";
+import { readFile, writeFile } from "node:fs/promises";
+
+const fwRoot =
+  process.env.LOGOS_QT_MCP ||
+  new URL("../result-mcp", import.meta.url).pathname;
+const { test, run } = await import(resolve(fwRoot, "test-framework/framework.mjs"));
+
+// The token config the app was launched with (same file the setup script writes).
+const TOKENS_CONFIG =
+  process.env.TOKENS_CONFIG ||
+  new URL("./testnet/amm-tokens.json", import.meta.url).pathname;
+
+// --- small helpers (mirrors swap.mjs) --------------------------------------
+
+const ignore = async (fn) => { try { return await fn(); } catch { /* best effort */ } };
+
+async function idByObjectName(app, name) {
+  const res = await app.findByProperty("objectName", name);
+  if (res.error || !res.matches || res.matches.length === 0)
+    throw new Error(`no object with objectName="${name}" (is the app on the Liquidity tab?)`);
+  return res.matches[0].id;
+}
+
+async function prop(app, id, name) {
+  const props = (await app.getProperties(id)).properties || [];
+  const p = props.find((x) => x.name === name);
+  return p ? p.value : undefined;
+}
+
+async function setProp(app, id, property, value) {
+  await app.inspector.send("setProperty", { objectId: id, property, value });
+}
+
+async function evaluate(app, id, expression) {
+  await app.inspector.send("evaluate", { expression, objectId: id });
+}
+
+// The NewPositionForm's create/pool state — explains WHY the CTA isn't ready.
+async function formState(app, formId) {
+  const props = (await app.getProperties(formId)).properties || [];
+  const get = (n) => { const p = props.find((x) => x.name === n); return p ? p.value : undefined; };
+  return {
+    poolStatus: get("poolStatus"),
+    missingPool: get("missingPool"),
+    canConfirm: get("canConfirm"),
+    amountA: get("amountA"),
+    amountB: get("amountB"),
+    submitError: get("submitError"),
+    transactionId: get("transactionId"),
+  };
+}
+
+async function saveShot(app, name) {
+  const shot = await ignore(() => app.screenshot());
+  if (shot && shot.image) {
+    const path = new URL(`./${name}.png`, import.meta.url).pathname;
+    await writeFile(path, Buffer.from(shot.image, "base64"));
+    console.log(`    screenshot -> ${path}`);
+  }
+}
+
+// --- Swap-card token picker helpers (shared shape with swap.mjs), used only to
+//     read the A/C pool's on-chain state for the final assertion. ------------
+
+async function pickerOpen(app) {
+  const id = await idByObjectName(app, "tokenSelectorModal");
+  return (await prop(app, id, "visible")) === true;
+}
+
+async function openPicker(app, buttonObjectName) {
+  const btnId = await idByObjectName(app, buttonObjectName);
+  await app.inspector.send("click", { objectId: btnId });
+  await app.waitFor(
+    async () => { if (!(await pickerOpen(app))) throw new Error("picker not open"); },
+    { timeout: 5000, interval: 200, description: `open ${buttonObjectName}` },
+  );
+}
+
+async function pickToken(app, index) {
+  const res = await app.findByProperty("objectName", "tokenListItem");
+  const items = (res && res.matches) || [];
+  if (items.length <= index)
+    throw new Error(`token #${index + 1} not found — only ${items.length} in the list`);
+  await app.inspector.send("click", { objectId: items[index].id });
+  await app.waitFor(
+    async () => { if (await pickerOpen(app)) throw new Error("picker still open"); },
+    { timeout: 5000, interval: 200, description: `select token #${index + 1}` },
+  );
+}
+
+// --- the test ---------------------------------------------------------------
+
+test("amm liquidity: create the A/C pool", async (app) => {
+  // Resolve the A and C token-definition ids from the launched token config.
+  const tokens = JSON.parse(await readFile(TOKENS_CONFIG, "utf8"));
+  const bySymbol = (s) => {
+    const t = tokens.find((x) => (x.symbol || "").toUpperCase() === s);
+    if (!t) throw new Error(`token ${s} not in ${TOKENS_CONFIG} — run the setup script`);
+    return t.definitionId;
+  };
+  const tokenA = bySymbol("TKA");
+  const tokenC = bySymbol("TKC");
+  console.log(`    create pool A(${tokenA.slice(0, 6)}…) / C(${tokenC.slice(0, 6)}…)`);
+
+  // 1. Switch to the Liquidity tab and wait for the form to render.
+  await app.waitFor(
+    async () => { await app.expectTexts(["Trade", "Liquidity"]); },
+    { timeout: 20000, interval: 500, description: "nav bar to load" },
+  );
+  await ignore(() => app.click("Liquidity"));
+  // waitFor resolves when the condition stops throwing — it does NOT return the
+  // callback's value, so fetch the id with a direct call afterwards.
+  await app.waitFor(
+    async () => { await idByObjectName(app, "newPositionForm"); },
+    { timeout: 10000, interval: 300, description: "liquidity form to render" },
+  );
+  const formId = await idByObjectName(app, "newPositionForm");
+
+  // 2. Select the A/C pair through selectToken() — the same entry point the token picker
+  //    uses — so the form runs its normal selection logic and resetPairDraft(), clearing any
+  //    persisted amounts/price/minimums from a reused app session and firing a fresh quote.
+  //    Setting selectedToken*Id directly would bypass that reset and could assert against
+  //    stale draft state. Both tokens are already in the config, so no async token resolution
+  //    is needed. The first missing-pool quote returns the minimum opening deposit, which
+  //    applyQuoteSideEffects auto-fills — so canConfirm becomes ready.
+  await evaluate(app, formId, `selectToken("A", "${tokenA}")`);
+  await evaluate(app, formId, `selectToken("B", "${tokenC}")`);
+
+  // Sanity: the selection must stick — the ids have to be present in the token
+  // config the app was launched with, or tokenById can't resolve them.
+  await app.waitFor(
+    async () => {
+      const a = await prop(app, formId, "selectedTokenAId");
+      const b = await prop(app, formId, "selectedTokenBId");
+      if (!a || !b) throw new Error(`pair not selected (A=${a} B=${b})`);
+    },
+    { timeout: 5000, interval: 300, description: "A/C pair selected" },
+  );
+  await evaluate(app, formId, "requestQuote(true)");
+
+  // 3. Wait for a submittable create quote (missing pool + funded minimum deposit).
+  try {
+    await app.waitFor(
+      async () => {
+        const s = await formState(app, formId);
+        if (s.poolStatus === "active_pool")
+          throw new Error("A/C pool already exists — reset the testnet (only A/B should be seeded)");
+        if (!s.canConfirm) throw new Error("create CTA not ready yet");
+      },
+      { timeout: 20000, interval: 500, description: "create CTA ready" },
+    );
+  } catch (e) {
+    await saveShot(app, "create-pool-cta-not-ready");
+    throw new Error(`${e.message}. Form state: ${JSON.stringify(await formState(app, formId))}`);
+  }
+  await saveShot(app, "create-pool-filled");
+  console.log(`    minimum deposit: A=${(await formState(app, formId)).amountA} C=${(await formState(app, formId)).amountB}`);
+
+  // 4. Submit -> confirmation dialog -> confirm.
+  const dialogId = await idByObjectName(app, "liquidityConfirmDialog");
+  const submitId = await idByObjectName(app, "newPositionSubmitButton");
+  await app.inspector.send("click", { objectId: submitId });
+
+  // QtQuick Controls Buttons don't reliably take the inspector's synthetic click,
+  // so if the dialog didn't open, emit the form's confirmationRequested signal
+  // directly (exactly what the button's onClicked does).
+  try {
+    await app.waitFor(
+      async () => { if ((await prop(app, dialogId, "visible")) !== true) throw new Error("not open"); },
+      { timeout: 4000, interval: 300, description: "confirm dialog open" },
+    );
+  } catch {
+    console.log("    submit click didn't take — emitting confirmationRequested via evaluate");
+    await ignore(() => evaluate(app, formId, "confirmationRequested(submissionSnapshot())"));
+    await app.waitFor(
+      async () => { if ((await prop(app, dialogId, "visible")) !== true) throw new Error("dialog not open"); },
+      { timeout: 8000, interval: 300, description: "confirm dialog open (after evaluate)" },
+    );
+  }
+
+  const confirmId = await idByObjectName(app, "transactionConfirmButton");
+  await app.inspector.send("click", { objectId: confirmId });
+  // QtQuick Buttons don't always take the synthetic click; fall back to invoking
+  // the dialog's confirm() slot directly (fires onConfirmed -> flow.confirm()).
+  try {
+    await app.waitFor(
+      async () => { if ((await prop(app, dialogId, "visible")) === true) throw new Error("still open"); },
+      { timeout: 3000, interval: 300, description: "confirm click registered" },
+    );
+  } catch {
+    console.log("    confirm button click didn't take — invoking confirm() via evaluate");
+    await ignore(() => evaluate(app, dialogId, "confirm()"));
+  }
+
+  // 5. Wait for the create to submit. It's fully async — createAccountPublic (mint
+  //    the LP holding) then createPool then the tx submit — so transactionId lands
+  //    a few seconds after confirm(), not immediately.
+  try {
+    await app.waitFor(
+      async () => {
+        const s = await formState(app, formId);
+        if (!s.transactionId) throw new Error("create not submitted yet");
+      },
+      { timeout: 30000, interval: 1000, description: "create to submit (transactionId set)" },
+    );
+  } catch {
+    await saveShot(app, "create-pool-result");
+    throw new Error(`create did not submit. Form state: ${JSON.stringify(await formState(app, formId))}`);
+  }
+  const final = await formState(app, formId);
+  console.log(`    create submitted: tx ${final.transactionId}`);
+
+  // 6. Verify ON-CHAIN via the Swap card's resolvePool — a plain hex pool read
+  //    against the sequencer (createPool has no tx poll / poolStatus, so we don't
+  //    lean on the liquidity form's legacy quote). Selecting A/C on the Trade tab
+  //    must now report the pool as existing with reserves.
+  await ignore(() => app.click("Trade"));
+  await app.waitFor(
+    async () => { await app.expectTexts(["Sell", "Buy"]); },
+    { timeout: 10000, interval: 500, description: "swap card to load" },
+  );
+  await openPicker(app, "swapSellTokenButton");
+  await pickToken(app, 0); // TKA
+  await openPicker(app, "swapBuyTokenButton");
+  await pickToken(app, 2); // TKC
+  const swapId = await idByObjectName(app, "swapCard");
+
+  try {
+    await app.waitFor(
+      async () => {
+        // Force a fresh read each poll — the create block may not be applied yet.
+        await ignore(() => evaluate(app, swapId, "doResolvePool()"));
+        await new Promise((r) => setTimeout(r, 800));
+        if ((await prop(app, swapId, "poolExists")) !== true)
+          throw new Error("A/C pool not found yet");
+      },
+      { timeout: 40000, interval: 1500, description: "A/C pool to exist on-chain" },
+    );
+  } catch {
+    await saveShot(app, "create-pool-result");
+    throw new Error(
+      `A/C pool not found on-chain after the create (tx ${final.transactionId}).\n` +
+      `  swap card: poolExists=${await prop(app, swapId, "poolExists")} ` +
+      `reserveA=${await prop(app, swapId, "poolReserveA")} ` +
+      `reserveB=${await prop(app, swapId, "poolReserveB")}`,
+    );
+  }
+  const rA = await prop(app, swapId, "poolReserveA");
+  const rB = await prop(app, swapId, "poolReserveB");
+  console.log(`    A/C pool exists on-chain  ✓  reserves A=${rA} B=${rB}  (tx ${final.transactionId})`);
+  await saveShot(app, "create-pool-result");
+});
+
+run();
+
+// How to run (from scratch, interactive + CI): see the "Running the UI tests"
+// section in apps/amm/tests/README.md — same flow as swap.mjs.

--- a/apps/amm/tests/qml/tst_LiquidityPage.qml
+++ b/apps/amm/tests/qml/tst_LiquidityPage.qml
@@ -191,44 +191,6 @@ TestCase {
         compare(page.flow.submitting, false)
     }
 
-    function test_base58MissingPoolSubmissionStartsPoolWatch() {
-        var backend = createTemporaryObject(backendComponent, testCase, {
-            "walletStateReady": true,
-            "submitResult": {
-                "status": "submitted",
-                "transactionId": submittedTransactionId,
-                "deadlineMs": String(Date.now() + 60000)
-            }
-        })
-        var runtime = createTemporaryObject(runtimeComponent, testCase)
-        var page = createTemporaryObject(pageComponent, testCase, {
-            "backend": backend,
-            "runtime": runtime
-        })
-        verify(backend)
-        verify(runtime)
-        verify(page)
-
-        var probe = {
-            "tokenAId": "22222222222222222222222222222222",
-            "tokenBId": "33333333333333333333333333333333"
-        }
-        page.flow.pendingQuoteRequest = { "ok": true, "request": probe }
-        page.flow.confirm({
-            "request": {
-                "initialPriceRealRaw": "18446744073709551616"
-            },
-            "poolProbeRequest": probe,
-            "quoteHash": "sha256:expected"
-        })
-        wait(0)
-
-        compare(page.flow.transactionId, submittedTransactionId)
-        compare(page.flow.pendingPoolProbes.length, 1)
-        compare(page.flow.selectedPoolCreationPending(), true)
-        compare(page.flow.poolProbeInFlight, false)
-    }
-
     function test_nativeHexSubmittedResultDoesNotEnterSuccessState() {
         var backend = createTemporaryObject(backendComponent, testCase, {
             "walletStateReady": true,
@@ -257,70 +219,4 @@ TestCase {
         compare(page.flow.submitting, false)
     }
 
-    function test_poolProbeDoesNotPublishProbeAmountsAsCurrentQuote() {
-        var backend = createTemporaryObject(backendComponent, testCase, {
-            "walletStateReady": true
-        })
-        var page = createTemporaryObject(pageComponent, testCase, {
-            "backend": backend
-        })
-        verify(backend)
-        verify(page)
-
-        var request = {
-            "tokenAId": "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
-            "tokenBId": "22222222222222222222222222222222"
-        }
-        var pending = { "key": page.flow.pairKey(request), "request": request }
-        page.flow.pendingQuoteRequest = { "ok": true, "request": request }
-        page.flow.pendingPoolProbes = [pending]
-        page.flow.newPositionQuote = {
-            "status": "ok",
-            "poolStatus": "missing_pool",
-            "tokenAId": request.tokenAId,
-            "tokenBId": request.tokenBId
-        }
-        page.flow.quoteStale = false
-
-        page.flow.finishPoolProbe(pending, {
-            "status": "ok",
-            "poolStatus": "active_pool",
-            "tokenAId": request.tokenAId,
-            "tokenBId": request.tokenBId
-        })
-
-        compare(page.flow.pendingPoolProbes.length, 0)
-        compare(page.flow.newPositionQuote.poolStatus, "missing_pool")
-        verify(page.flow.quoteStale)
-    }
-
-    function test_poolProbeStopsBlockingAfterTransactionDeadline() {
-        var backend = createTemporaryObject(backendComponent, testCase, {
-            "walletStateReady": true
-        })
-        var page = createTemporaryObject(pageComponent, testCase, {
-            "backend": backend
-        })
-        verify(backend)
-        verify(page)
-
-        var request = {
-            "tokenAId": "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
-            "tokenBId": "22222222222222222222222222222222"
-        }
-        var pending = {
-            "key": page.flow.pairKey(request),
-            "request": request,
-            "deadlineMs": Date.now() - 1
-        }
-        page.flow.pendingQuoteRequest = { "ok": true, "request": request }
-        page.flow.pendingPoolProbes = [pending]
-        page.flow.poolProbeInFlight = true
-
-        page.flow.finishPoolProbe(pending, null)
-
-        compare(page.flow.pendingPoolProbes.length, 0)
-        compare(page.flow.poolProbeInFlight, false)
-        verify(!page.flow.selectedPoolCreationPending())
-    }
 }

--- a/apps/amm/tests/qml/tst_NewPositionForm.qml
+++ b/apps/amm/tests/qml/tst_NewPositionForm.qml
@@ -266,8 +266,14 @@ TestCase {
         verify(amountBInput)
         compare(amountAInput.selectedTokenId, tokenLow)
         compare(amountBInput.selectedTokenId, tokenHigh)
-        verify(amountAInput.height <= 114)
-        verify(amountBInput.height <= 114)
+        // missing_pool now renders the holding-selector footer, so the input card grows by the
+        // footer's own height plus its extra bottom spacing (the surface adds footerHeight + 30
+        // when a footer is active vs + 24 without one, i.e. footerHeight + 6 over the pre-footer
+        // bound). Keep the compactness guard, but make it footer-aware.
+        verify(amountAInput.footerActive) // the holding-selector footer is present in missing_pool
+        verify(amountBInput.footerActive)
+        verify(amountAInput.height <= 114 + amountAInput.footerHeight + 6)
+        verify(amountBInput.height <= 114 + amountBInput.footerHeight + 6)
         verify(findChild(form, "priceAmountAField"))
         verify(findChild(form, "priceAmountBField"))
 

--- a/apps/amm/tests/qml/tst_NewPositionForm.qml
+++ b/apps/amm/tests/qml/tst_NewPositionForm.qml
@@ -345,36 +345,6 @@ TestCase {
         compare(form.amountA, "2")
     }
 
-    function test_poolActivationClearsCreationDraftWithoutPublishingProbeAmounts() {
-        var form = createForm()
-        form.confirmedPoolStatus = "missing_pool"
-        form.amountA = "3"
-        form.amountB = "2"
-        form.minimumAmountARaw = "3"
-        form.minimumAmountBRaw = "2000000"
-
-        verify(form.acceptPoolActivation({
-            "status": "ok",
-            "tokenAId": tokenHigh,
-            "tokenBId": tokenLow,
-            "poolStatus": "active_pool",
-            "reserveARaw": "3000000",
-            "reserveBRaw": "2"
-        }))
-
-        verify(form.activePool)
-        compare(form.activePoolQuote.poolStatus, "active_pool")
-        compare(form.amountA, "")
-        compare(form.amountB, "")
-        compare(form.minimumAmountARaw, "")
-        compare(form.minimumAmountBRaw, "")
-        quoteRequestedSpy.target = form
-        quoteRequestedSpy.clear()
-        form.requestQuote(true)
-        compare(quoteRequestedSpy.count, 0)
-        compare(form.localErrors.length, 0)
-    }
-
     function test_staleQuoteErrorsDoNotMarkCurrentDraft() {
         var quote = {
             "status": "ok",

--- a/apps/amm/tests/swap.mjs
+++ b/apps/amm/tests/swap.mjs
@@ -84,6 +84,38 @@ async function pickToken(app, index) {
   return symbol;
 }
 
+// Pick the funding account for a swap side. The selector auto-selects when the
+// wallet holds the token in exactly one account, but make the choice explicit (and robust
+// to multi-account wallets with zero-balance holdings): wait for the holdings to populate,
+// then select the highest-balance match. canSubmit now requires BOTH sides' holdings to be
+// set, so a swap can't be submitted until this runs.
+async function selectAccount(app, selectorObjectName) {
+  const id = await idByObjectName(app, selectorObjectName);
+  await app.waitFor(
+    async () => { if ((await prop(app, id, "hasFunds")) !== true) throw new Error("no matching holdings yet"); },
+    { timeout: 10000, interval: 300, description: `${selectorObjectName} holdings to load` },
+  );
+  // setSelection/accountIdFor/matchingAccounts/valueFor are members of the selector, so
+  // evaluate in its own QML context (same pragmatic style as setSellAmount). tokenHoldings can
+  // include zero-balance holdings for the token, and hasFunds only checks the match COUNT — so
+  // pick the matching account with the largest balanceRaw rather than matchingAccounts[0],
+  // which could be an empty holding the swap transfer can't debit. balanceRaw values are
+  // non-negative base-unit integer strings, so "longer wins, else lexicographic" is an exact
+  // max without needing BigInt.
+  await app.inspector.send("evaluate", {
+    expression:
+      "(function(){var r=matchingAccounts,b=r[0],bb=String(valueFor(b,'balanceRaw')||'0');"
+      + "for(var i=1;i<r.length;++i){var v=String(valueFor(r[i],'balanceRaw')||'0');"
+      + "if(v.length>bb.length||(v.length===bb.length&&v>bb)){b=r[i];bb=v;}}"
+      + "setSelection(accountIdFor(b),false);})()",
+    objectId: id,
+  });
+  await app.waitFor(
+    async () => { if (!(await prop(app, id, "selectedAccountId"))) throw new Error("holding not selected yet"); },
+    { timeout: 5000, interval: 200, description: `${selectorObjectName} holding selected` },
+  );
+}
+
 // Enter the sell amount by setting the SwapCard's state directly. Synthesizing
 // keystrokes needs the TextInput to hold active focus, which the inspector
 // can't reliably grant headlessly; setting sellInput updates the property (and
@@ -118,6 +150,8 @@ async function cardState(app) {
     swapError: get("swapError"),
     canSubmit: get("canSubmit"),
     submitButtonText: get("submitButtonText"),
+    sellHolding: get("sellHolding"),
+    buyHolding: get("buyHolding"),
   };
 }
 
@@ -160,6 +194,10 @@ test("amm swap: sell token #1 for token #2", async (app) => {
   await openPicker(app, "swapBuyTokenButton");
   const second = await pickToken(app, 1);
   console.log(`    sell ${first} -> buy ${second}`);
+
+  // 4. Pick the funding account for each side (canSubmit needs both selected).
+  await selectAccount(app, "swapSellAccountSelector");
+  await selectAccount(app, "swapBuyAccountSelector");
 
   // 5. Enter the sell amount.
   await setSellAmount(app, SELL_AMOUNT);

--- a/apps/amm/tests/testnet/setup-amm-testnet.sh
+++ b/apps/amm/tests/testnet/setup-amm-testnet.sh
@@ -2,11 +2,12 @@
 #
 # setup-amm-testnet.sh
 # --------------------
-# Deploy the token/amm/twap programs, mint two fungible tokens, initialize the
-# AMM, and create a pool — from scratch — against whatever sequencer your
-# `wallet` / `spel` config points at. This is the prerequisite state that the
-# AMM UI swap test (apps/amm/tests/swap.mjs) exercises; run it once to stand up
-# a swappable pool, then launch the UI / run the test.
+# Deploy the token/amm/twap programs, mint three fungible tokens, initialize the
+# AMM, and create the A/B pool — from scratch — against whatever sequencer your
+# `wallet` / `spel` config points at. This is the prerequisite state the AMM UI
+# tests exercise: swap.mjs swaps against the seeded A/B pool, and create-pool.mjs
+# creates the (deliberately unseeded) A/C pool. Run it once, then launch the UI /
+# run the tests.
 #
 # DETERMINISTIC TEST WALLET: by default the script bootstraps an ISOLATED wallet
 # (git-ignored, under this folder) by restoring it from a fixed BIP-39 mnemonic
@@ -63,7 +64,10 @@ TEST_SEQUENCER_ADDR="${TEST_SEQUENCER_ADDR:-}"
 
 # Deterministic accounts, created in THIS fixed order after a fresh restore so
 # their ids are reproducible. Resolved to ids at runtime via `wallet account id`.
-ACCOUNT_LABELS=(token-a-def token-a-holding token-b-def token-b-holding lp-holding)
+# token-c-* are APPENDED (not inserted) so the pre-existing a/b/lp ids don't shift.
+# Token C has no seeded pool — the create-pool UI test (apps/amm/tests/create-pool.mjs)
+# creates the A/C pool itself, minting its own LP holding via the app.
+ACCOUNT_LABELS=(token-a-def token-a-holding token-b-def token-b-holding lp-holding token-c-def token-c-holding)
 
 ###############################################################################
 # CONFIG — non-account parameters (edit freely)
@@ -81,6 +85,7 @@ AMM_IDL="artifacts/amm-idl.json"
 # --- Token metadata ---
 TOKEN_A_NAME="TOKEN A"; TOKEN_A_SYMBOL="TKA"; TOKEN_A_SUPPLY="1000000000000000000000"; TOKEN_A_DECIMALS=18
 TOKEN_B_NAME="TOKEN B"; TOKEN_B_SYMBOL="TKB"; TOKEN_B_SUPPLY="1000000000000000000000"; TOKEN_B_DECIMALS=18
+TOKEN_C_NAME="TOKEN C"; TOKEN_C_SYMBOL="TKC"; TOKEN_C_SUPPLY="1000000000000000000000"; TOKEN_C_DECIMALS=18
 
 # --- Pool inputs ---
 CLOCK_ACCOUNT="4BdcjoXkq786TMWcBGGHqcxeLYMZmn17rL4eM9ZyRWNU"  # canonical LEZ system clock
@@ -172,10 +177,11 @@ acct_id() {
   printf '%s' "$out" | grep -oE '[1-9A-HJ-NP-Za-km-z]{32,44}' | head -n1
 }
 
-# Restore the isolated test wallet from the fixed mnemonic and register the
-# deterministic accounts. `restore-keys` REWRITES storage (safe here — it's a
-# throwaway test home). Idempotent: skips accounts that already resolve.
-bootstrap_test_wallet() {
+# Restore the isolated test wallet from the fixed mnemonic. `restore-keys`
+# REWRITES storage (safe here — it's a throwaway test home). Only the key
+# material is restored here; account registration is a separate idempotent step
+# (ensure_accounts) so adding a label doesn't require a full re-restore.
+restore_test_wallet() {
   sec "Bootstrap deterministic test wallet"
   kv "wallet home" "$TEST_WALLET_HOME"
   mkdir -p "$TEST_WALLET_HOME"
@@ -198,14 +204,24 @@ bootstrap_test_wallet() {
   printf '%s\n%s\n' "$TEST_MNEMONIC" "$TEST_WALLET_PASSWORD" \
     | wallet restore-keys --depth "$TEST_WALLET_DEPTH" \
     || die "wallet restore-keys failed"
+}
 
+# Register the deterministic accounts, in ACCOUNT_LABELS order. Idempotent —
+# skips accounts that already resolve, so newly-appended labels (e.g. token-c-*)
+# are created on an existing wallet WITHOUT re-restoring keys. Their ids stay
+# deterministic because they're appended after the pre-existing accounts.
+ensure_accounts() {
+  sec "Ensure deterministic test accounts"
   local label
   for label in "${ACCOUNT_LABELS[@]}"; do
     if acct_id "$label" >/dev/null 2>&1; then
       kv "exists" "$label"
     else
       log "${DIM}\$ wallet account new public --label $label${RST}"
-      wallet account new public --label "$label" || die "failed to create account: $label"
+      # Feed the password in case the wallet prompts to unlock before writing.
+      printf '%s\n' "$TEST_WALLET_PASSWORD" \
+        | wallet account new public --label "$label" \
+        || die "failed to create account: $label (try FORCE_BOOTSTRAP=1 to re-restore)"
     fi
   done
 }
@@ -223,10 +239,13 @@ kv "repo root"        "$REPO_ROOT"
 kv "token bin" "$TOKEN_BIN"; kv "amm bin" "$AMM_BIN"; kv "twap bin" "$TWAP_BIN"
 
 if [ ! -d "$TEST_WALLET_HOME" ] || [ "${FORCE_BOOTSTRAP:-0}" = "1" ]; then
-  bootstrap_test_wallet
+  restore_test_wallet
 else
-  kv "test wallet" "reusing $TEST_WALLET_HOME (FORCE_BOOTSTRAP=1 to re-restore)"
+  kv "test wallet" "reusing $TEST_WALLET_HOME (FORCE_BOOTSTRAP=1 to re-restore keys)"
 fi
+# Always register accounts — creates any newly-added labels (e.g. token-c-*) on
+# an existing wallet without a full key re-restore.
+ensure_accounts
 
 ###############################################################################
 # 1. Resolve the deterministic test accounts
@@ -237,12 +256,14 @@ TOKEN_A_HOLDING="$(acct_id token-a-holding)" || die "token-a-holding not registe
 TOKEN_B_DEF="$(acct_id token-b-def)"        || die "token-b-def not registered"
 TOKEN_B_HOLDING="$(acct_id token-b-holding)" || die "token-b-holding not registered"
 USER_HOLDING_LP="$(acct_id lp-holding)"     || die "lp-holding not registered"
-for v in TOKEN_A_DEF TOKEN_A_HOLDING TOKEN_B_DEF TOKEN_B_HOLDING USER_HOLDING_LP; do
+TOKEN_C_DEF="$(acct_id token-c-def)"        || die "token-c-def not registered"
+TOKEN_C_HOLDING="$(acct_id token-c-holding)" || die "token-c-holding not registered"
+for v in TOKEN_A_DEF TOKEN_A_HOLDING TOKEN_B_DEF TOKEN_B_HOLDING USER_HOLDING_LP TOKEN_C_DEF TOKEN_C_HOLDING; do
   [ -n "${!v}" ] || die "failed to resolve account id for $v"
 done
 
 # Derived roles (the input holding signs; mint authority == holding; authority is the A holding).
-TOKEN_A_MINT_AUTH="$TOKEN_A_HOLDING"; TOKEN_B_MINT_AUTH="$TOKEN_B_HOLDING"
+TOKEN_A_MINT_AUTH="$TOKEN_A_HOLDING"; TOKEN_B_MINT_AUTH="$TOKEN_B_HOLDING"; TOKEN_C_MINT_AUTH="$TOKEN_C_HOLDING"
 AMM_AUTHORITY="$TOKEN_A_HOLDING"
 USER_HOLDING_A="$TOKEN_A_HOLDING"; USER_HOLDING_B="$TOKEN_B_HOLDING"
 
@@ -251,6 +272,8 @@ kv "token-a-holding" "$TOKEN_A_HOLDING"
 kv "token-b-def"     "$TOKEN_B_DEF"
 kv "token-b-holding" "$TOKEN_B_HOLDING"
 kv "lp-holding"      "$USER_HOLDING_LP"
+kv "token-c-def"     "$TOKEN_C_DEF"
+kv "token-c-holding" "$TOKEN_C_HOLDING"
 
 ###############################################################################
 # 2. Deploy programs
@@ -284,6 +307,14 @@ run_tx strict "create fungible definition: $TOKEN_B_NAME" -- \
     --holding-target-account "$TOKEN_B_HOLDING" \
     --mint-authority "$TOKEN_B_MINT_AUTH"
 
+# Token C has no seeded pool — the create-pool UI test creates the A/C pool.
+run_tx strict "create fungible definition: $TOKEN_C_NAME" -- \
+  spel --idl "$TOKEN_IDL" --program "$TOKEN_BIN" -- new-fungible-definition \
+    --name "$TOKEN_C_NAME" --total-supply "$TOKEN_C_SUPPLY" \
+    --definition-target-account "$TOKEN_C_DEF" \
+    --holding-target-account "$TOKEN_C_HOLDING" \
+    --mint-authority "$TOKEN_C_MINT_AUTH"
+
 ###############################################################################
 # 5. Verify token definitions & holdings
 ###############################################################################
@@ -291,6 +322,8 @@ inspect "$TOKEN_IDL" "$TOKEN_A_DEF"     "TokenDefinition"
 inspect "$TOKEN_IDL" "$TOKEN_A_HOLDING" "TokenHolding"
 inspect "$TOKEN_IDL" "$TOKEN_B_DEF"     "TokenDefinition"
 inspect "$TOKEN_IDL" "$TOKEN_B_HOLDING" "TokenHolding"
+inspect "$TOKEN_IDL" "$TOKEN_C_DEF"     "TokenDefinition"
+inspect "$TOKEN_IDL" "$TOKEN_C_HOLDING" "TokenHolding"
 
 ###############################################################################
 # 6. Derive AMM PDAs from the program ids + token pair
@@ -378,6 +411,13 @@ cat > "$TOKENS_CONFIG_OUT" <<JSON
     "definitionId": "$TOKEN_B_DEF",
     "holding": "$TOKEN_B_HOLDING",
     "decimals": $TOKEN_B_DECIMALS
+  },
+  {
+    "symbol": "$TOKEN_C_SYMBOL",
+    "name": "$TOKEN_C_NAME",
+    "definitionId": "$TOKEN_C_DEF",
+    "holding": "$TOKEN_C_HOLDING",
+    "decimals": $TOKEN_C_DECIMALS
   }
 ]
 JSON
@@ -394,4 +434,5 @@ log "  ${DIM}LEE_WALLET_HOME_DIR=$TEST_WALLET_HOME \\${RST}"
 log "  ${DIM}  AMM_PROGRAM_BIN=$REPO_ROOT/$AMM_BIN \\${RST}"
 log "  ${DIM}  TOKENS_CONFIG=$REPO_ROOT/$TOKENS_CONFIG_OUT \\${RST}"
 log "  ${DIM}  nix run .#amm-ui${RST}"
-log "Then in another terminal: ${DIM}node apps/amm/tests/swap.mjs${RST}"
+log "Then in another terminal: ${DIM}node apps/amm/tests/swap.mjs${RST}  (swap A/B)"
+log "                   or:     ${DIM}node apps/amm/tests/create-pool.mjs${RST}  (create A/C pool)"

--- a/apps/shared/wallet/CMakeLists.txt
+++ b/apps/shared/wallet/CMakeLists.txt
@@ -67,6 +67,7 @@ if(LOGOS_WALLET_BUILD_QML)
     )
     set(wallet_public_qml
         qml/WalletControl.qml
+        qml/ProgramAccountSelector.qml
         qml/TransactionConfirmationDialog.qml
         qml/SubmittedTransaction.qml
     )

--- a/apps/shared/wallet/qml/ProgramAccountSelector.qml
+++ b/apps/shared/wallet/qml/ProgramAccountSelector.qml
@@ -1,0 +1,362 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls.Basic
+
+Item {
+    id: root
+
+    enum SelectionMode {
+        Input,
+        Output
+    }
+
+    property var sourceModel: []
+    property string accountType: ""
+    property string stateField: ""
+    property var stateValue: ""
+    property int selectionMode: ProgramAccountSelector.Input
+    property string selectedAccountId: ""
+    property bool createNewSelected: false
+    property string createNewText: qsTr("Create new account")
+    property string emptyInputText: qsTr("No funds")
+    property string placeholderText: qsTr("Select account")
+    property string criteriaPendingText: qsTr("Select token first")
+    property string accessibleName: qsTr("Program account")
+    property color backgroundColor: "#27272a"
+    property color hoverColor: "#3f3f46"
+    property color textColor: "#f4f4f5"
+    property color secondaryTextColor: "#a1a1aa"
+    property color borderColor: "#52525b"
+    property color focusColor: "#f26a21"
+    property int modelRevision: 0
+
+    readonly property bool criteriaReady: root.accountType.length > 0
+                                                  && (root.stateField.length === 0
+                                                      || root.scalarText(root.stateValue).length > 0)
+    readonly property var matchingAccounts: root.filteredAccounts()
+    readonly property var choices: root.choiceRows()
+    readonly property bool hasFunds: root.matchingAccounts.length > 0
+    readonly property bool selectionValid: root.accountById(root.selectedAccountId) !== null
+    readonly property bool ready: root.criteriaReady
+                                  && (root.selectionValid
+                                      || (root.selectionMode === ProgramAccountSelector.Output
+                                          && root.createNewSelected))
+    readonly property var selectedAccount: root.accountById(root.selectedAccountId)
+    readonly property string selectedBalanceRaw: root.selectedAccount
+                                                        ? String(root.valueFor(
+                                                                     root.selectedAccount,
+                                                                     "balanceRaw") || "0")
+                                                        : "0"
+    readonly property bool showCombo: root.selectionMode === ProgramAccountSelector.Output
+                                      || (root.criteriaReady
+                                          && root.matchingAccounts.length > 1)
+    readonly property bool showEmptyInput: root.selectionMode === ProgramAccountSelector.Input
+                                           && root.criteriaReady
+                                           && root.matchingAccounts.length === 0
+
+    signal selectionChanged(string accountId, bool createNew)
+
+    implicitWidth: 220
+    implicitHeight: root.showCombo ? 34 : root.showEmptyInput ? 20 : 0
+    visible: implicitHeight > 0
+
+    Instantiator {
+        id: rows
+
+        model: root.sourceModel
+        delegate: QtObject {
+            required property var model
+            required property var modelData
+
+            readonly property var accountRow: {
+                if (modelData !== null && typeof modelData === "object") {
+                    return modelData
+                }
+                if (model === null || typeof model !== "object")
+                    return ({})
+                return {
+                    "accountId": model.accountId,
+                    "address": model.address,
+                    "displayAddress": model.displayAddress,
+                    "accountType": model.accountType,
+                    "definitionId": model.definitionId,
+                    "balanceRaw": model.balanceRaw,
+                    "state": model.state
+                }
+            }
+        }
+        onObjectAdded: function(index, object) {
+            ++root.modelRevision
+            Qt.callLater(root.reconcileSelection)
+        }
+        onObjectRemoved: function(index, object) {
+            ++root.modelRevision
+            Qt.callLater(root.reconcileSelection)
+        }
+    }
+
+    onSourceModelChanged: Qt.callLater(root.reconcileSelection)
+    onAccountTypeChanged: Qt.callLater(root.reconcileSelection)
+    onStateFieldChanged: Qt.callLater(root.reconcileSelection)
+    onStateValueChanged: Qt.callLater(root.reconcileSelection)
+    onSelectionModeChanged: Qt.callLater(root.reconcileSelection)
+    Component.onCompleted: Qt.callLater(root.reconcileSelection)
+
+    Text {
+        anchors.fill: parent
+        visible: root.showEmptyInput
+        text: root.emptyInputText
+        color: root.secondaryTextColor
+        font.pixelSize: 11
+        verticalAlignment: Text.AlignVCenter
+        Accessible.role: Accessible.StaticText
+        Accessible.name: text
+    }
+
+    ComboBox {
+        id: accountCombo
+
+        objectName: "programAccountComboBox"
+        anchors.fill: parent
+        visible: root.showCombo
+        enabled: root.enabled && root.criteriaReady && root.choices.length > 0
+        model: root.choices
+        currentIndex: root.choiceIndex()
+        displayText: root.displayLabel()
+        leftPadding: 10
+        rightPadding: 28
+        topPadding: 0
+        bottomPadding: 0
+        hoverEnabled: true
+        activeFocusOnTab: true
+        focusPolicy: Qt.StrongFocus
+        Accessible.name: root.accessibleName
+
+        contentItem: Text {
+            leftPadding: accountCombo.leftPadding
+            rightPadding: accountCombo.rightPadding
+            text: accountCombo.displayText
+            color: accountCombo.enabled ? root.textColor : root.secondaryTextColor
+            font.pixelSize: 11
+            verticalAlignment: Text.AlignVCenter
+            elide: Text.ElideMiddle
+        }
+
+        indicator: Text {
+            x: accountCombo.width - width - 10
+            y: Math.round((accountCombo.height - height) / 2)
+            text: "\u25BE"
+            color: accountCombo.enabled ? root.secondaryTextColor : root.borderColor
+            font.pixelSize: 10
+        }
+
+        background: Rectangle {
+            radius: 7
+            color: !accountCombo.enabled
+                   ? root.backgroundColor
+                   : accountCombo.down || accountCombo.hovered
+                     ? root.hoverColor : root.backgroundColor
+            border.color: accountCombo.activeFocus ? root.focusColor : root.borderColor
+            border.width: 1
+        }
+
+        delegate: ItemDelegate {
+            id: optionDelegate
+
+            required property int index
+            required property var modelData
+
+            width: ListView.view ? ListView.view.width : accountCombo.width
+            height: 34
+            hoverEnabled: true
+            highlighted: accountCombo.highlightedIndex === optionDelegate.index
+
+            contentItem: Text {
+                leftPadding: 8
+                rightPadding: 8
+                text: root.labelFor(optionDelegate.modelData)
+                color: root.textColor
+                font.pixelSize: 11
+                verticalAlignment: Text.AlignVCenter
+                elide: Text.ElideMiddle
+            }
+
+            background: Rectangle {
+                radius: 5
+                color: optionDelegate.highlighted || optionDelegate.hovered
+                       ? root.hoverColor : "transparent"
+            }
+        }
+
+        popup: Popup {
+            y: accountCombo.height + 4
+            width: accountCombo.width
+            implicitHeight: Math.min(contentItem.implicitHeight + topPadding + bottomPadding,
+                                     204)
+            padding: 4
+            closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+
+            contentItem: ListView {
+                clip: true
+                implicitHeight: contentHeight
+                model: accountCombo.delegateModel
+                currentIndex: accountCombo.highlightedIndex
+                highlightMoveDuration: 0
+                ScrollIndicator.vertical: ScrollIndicator { }
+            }
+
+            background: Rectangle {
+                radius: 7
+                color: root.backgroundColor
+                border.color: root.borderColor
+                border.width: 1
+            }
+        }
+
+        onActivated: function(index) {
+            const choice = root.choices[index]
+            if (!choice)
+                return
+            root.setSelection(choice.createNew === true
+                              ? "" : root.accountIdFor(choice),
+                              choice.createNew === true)
+        }
+    }
+
+    function filteredAccounts() {
+        root.modelRevision
+        if (!root.criteriaReady)
+            return []
+        const result = []
+        for (let index = 0; index < rows.count; ++index) {
+            const object = rows.objectAt(index)
+            const row = object ? root.valueFor(object, "accountRow") : null
+            if (!row)
+                continue
+            const type = String(root.valueFor(row, "accountType")
+                                || root.valueFor(row, "typeName")
+                                || root.valueFor(row, "programType") || "")
+            if (type !== root.accountType)
+                continue
+            if (root.stateField.length > 0
+                    && root.scalarText(root.valueFor(row, root.stateField))
+                       !== root.scalarText(root.stateValue)) {
+                continue
+            }
+            if (root.accountIdFor(row).length > 0)
+                result.push(row)
+        }
+        return result
+    }
+
+    function valueFor(row, field) {
+        if (!row)
+            return undefined
+        if (row[field] !== undefined)
+            return row[field]
+        if (row.state && row.state[field] !== undefined)
+            return row.state[field]
+        if (row.fields && row.fields[field] !== undefined)
+            return row.fields[field]
+        return undefined
+    }
+
+    function scalarText(value) {
+        return value === undefined || value === null ? "" : String(value)
+    }
+
+    function accountIdFor(row) {
+        return String(root.valueFor(row, "accountId")
+                      || root.valueFor(row, "displayAddress")
+                      || root.valueFor(row, "address")
+                      || root.valueFor(row, "holdingId") || "")
+    }
+
+    function accountById(accountId) {
+        const value = String(accountId || "")
+        if (value.length === 0)
+            return null
+        for (let index = 0; index < root.matchingAccounts.length; ++index) {
+            if (root.accountIdFor(root.matchingAccounts[index]) === value)
+                return root.matchingAccounts[index]
+        }
+        return null
+    }
+
+    function choiceRows() {
+        const result = root.matchingAccounts.slice(0)
+        if (root.selectionMode === ProgramAccountSelector.Output)
+            result.push({ "createNew": true })
+        return result
+    }
+
+    function choiceIndex() {
+        if (root.createNewSelected)
+            return root.choices.length - 1
+        for (let index = 0; index < root.choices.length; ++index) {
+            if (root.accountIdFor(root.choices[index]) === root.selectedAccountId)
+                return index
+        }
+        return -1
+    }
+
+    function displayLabel() {
+        const index = root.choiceIndex()
+        if (index >= 0)
+            return root.labelFor(root.choices[index])
+        if (!root.criteriaReady)
+            return root.criteriaPendingText
+        return root.placeholderText
+    }
+
+    function labelFor(row) {
+        if (row && row.createNew === true)
+            return root.createNewText
+        const id = root.accountIdFor(row)
+        const balanceValue = root.valueFor(row, "balanceRaw")
+        const balance = balanceValue === undefined || balanceValue === null ? "" : String(balanceValue)
+        return balance.length > 0
+                ? qsTr("%1 · %2").arg(root.shortId(id)).arg(balance)
+                : root.shortId(id)
+    }
+
+    function shortId(value) {
+        const text = String(value || "")
+        return text.length > 14 ? text.slice(0, 7) + "..." + text.slice(-5) : text
+    }
+
+    function setSelection(accountId, createNew) {
+        const nextId = String(accountId || "")
+        const nextCreate = createNew === true
+        if (root.selectedAccountId === nextId && root.createNewSelected === nextCreate)
+            return
+        root.selectedAccountId = nextId
+        root.createNewSelected = nextCreate
+        root.selectionChanged(nextId, nextCreate)
+    }
+
+    function reconcileSelection() {
+        if (!root.criteriaReady) {
+            root.setSelection("", false)
+            return
+        }
+        if (root.selectionValid)
+            return
+        if (root.selectionMode === ProgramAccountSelector.Input) {
+            root.setSelection(root.matchingAccounts.length === 1
+                              ? root.accountIdFor(root.matchingAccounts[0]) : "",
+                              false)
+            return
+        }
+        if (root.createNewSelected)
+            return
+        if (root.matchingAccounts.length === 0) {
+            root.setSelection("", true)
+        } else if (root.matchingAccounts.length === 1) {
+            root.setSelection(root.accountIdFor(root.matchingAccounts[0]), false)
+        } else {
+            root.setSelection("", false)
+        }
+    }
+}

--- a/apps/shared/wallet/qml/ProgramAccountSelector.qml
+++ b/apps/shared/wallet/qml/ProgramAccountSelector.qml
@@ -29,6 +29,13 @@ Item {
     property color secondaryTextColor: "#a1a1aa"
     property color borderColor: "#52525b"
     property color focusColor: "#f26a21"
+    // Show the combo even when only one account matches. By default a single match
+    // auto-selects and hides (no choice to make); consumers that want the chosen
+    // holding always visible set this true.
+    property bool showWhenSingle: false
+    // Horizontal alignment of the selector's text (closed combo, dropdown rows and
+    // the empty "No funds" label). Defaults to left; consumers can right-align it.
+    property int textAlignment: Text.AlignLeft
     property int modelRevision: 0
 
     readonly property bool criteriaReady: root.accountType.length > 0
@@ -50,7 +57,8 @@ Item {
                                                         : "0"
     readonly property bool showCombo: root.selectionMode === ProgramAccountSelector.Output
                                       || (root.criteriaReady
-                                          && root.matchingAccounts.length > 1)
+                                          && root.matchingAccounts.length
+                                             > (root.showWhenSingle ? 0 : 1))
     readonly property bool showEmptyInput: root.selectionMode === ProgramAccountSelector.Input
                                            && root.criteriaReady
                                            && root.matchingAccounts.length === 0
@@ -110,6 +118,7 @@ Item {
         color: root.secondaryTextColor
         font.pixelSize: 11
         verticalAlignment: Text.AlignVCenter
+        horizontalAlignment: root.textAlignment
         Accessible.role: Accessible.StaticText
         Accessible.name: text
     }
@@ -140,6 +149,7 @@ Item {
             color: accountCombo.enabled ? root.textColor : root.secondaryTextColor
             font.pixelSize: 11
             verticalAlignment: Text.AlignVCenter
+            horizontalAlignment: root.textAlignment
             elide: Text.ElideMiddle
         }
 
@@ -179,6 +189,7 @@ Item {
                 color: root.textColor
                 font.pixelSize: 11
                 verticalAlignment: Text.AlignVCenter
+                horizontalAlignment: root.textAlignment
                 elide: Text.ElideMiddle
             }
 

--- a/apps/shared/wallet/tests/qml/tst_ProgramAccountSelector.qml
+++ b/apps/shared/wallet/tests/qml/tst_ProgramAccountSelector.qml
@@ -1,0 +1,152 @@
+import QtQuick
+import QtTest
+import Logos.Wallet as Wallet
+
+Item {
+    id: root
+
+    width: 480
+    height: 320
+
+    readonly property var holdingA: ({
+        "accountId": "holding-a",
+        "accountType": "TokenHolding",
+        "definitionId": "token-a",
+        "balanceRaw": "120"
+    })
+    readonly property var holdingB: ({
+        "accountId": "holding-b",
+        "accountType": "TokenHolding",
+        "state": {
+            "definitionId": "token-a",
+            "balanceRaw": "80"
+        }
+    })
+    readonly property var otherToken: ({
+        "accountId": "holding-c",
+        "accountType": "TokenHolding",
+        "definitionId": "token-b",
+        "balanceRaw": "50"
+    })
+    readonly property var otherType: ({
+        "accountId": "pool-a",
+        "accountType": "Pool",
+        "definitionId": "token-a"
+    })
+
+    Component {
+        id: selectorComponent
+
+        Wallet.ProgramAccountSelector {
+            width: 260
+            accountType: "TokenHolding"
+            stateField: "definitionId"
+            stateValue: "token-a"
+        }
+    }
+
+    TestCase {
+        name: "ProgramAccountSelector"
+        when: windowShown
+
+        function test_inputNoFunds() {
+            const selector = createTemporaryObject(selectorComponent, root, {
+                "sourceModel": [root.otherToken, root.otherType],
+                "selectionMode": Wallet.ProgramAccountSelector.Input
+            })
+            verify(!!selector, "Component exists")
+            tryCompare(selector, "showEmptyInput", true)
+            compare(selector.showCombo, false)
+            compare(selector.hasFunds, false)
+            compare(selector.ready, false)
+            compare(selector.selectedAccountId, "")
+        }
+
+        function test_inputSingleHoldingAutoSelectsWithoutCombo() {
+            const selector = createTemporaryObject(selectorComponent, root, {
+                "sourceModel": [root.holdingA, root.otherToken],
+                "selectionMode": Wallet.ProgramAccountSelector.Input
+            })
+            verify(!!selector, "Component exists")
+            tryCompare(selector, "selectedAccountId", "holding-a")
+            compare(selector.showCombo, false)
+            compare(selector.hasFunds, true)
+            compare(selector.ready, true)
+            compare(selector.selectedBalanceRaw, "120")
+        }
+
+        function test_inputMultipleHoldingsRequiresSelection() {
+            const selector = createTemporaryObject(selectorComponent, root, {
+                "sourceModel": [root.holdingA, root.holdingB],
+                "selectionMode": Wallet.ProgramAccountSelector.Input
+            })
+            verify(!!selector, "Component exists")
+            tryCompare(selector, "showCombo", true)
+            compare(selector.matchingAccounts.length, 2)
+            compare(selector.ready, false)
+
+            selector.setSelection("holding-b", false)
+            compare(selector.selectedAccountId, "holding-b")
+            compare(selector.selectedBalanceRaw, "80")
+            compare(selector.ready, true)
+        }
+
+        function test_outputNoHoldingSelectsCreateNew() {
+            const selector = createTemporaryObject(selectorComponent, root, {
+                "sourceModel": [],
+                "selectionMode": Wallet.ProgramAccountSelector.Output
+            })
+            verify(!!selector, "Component exists")
+            tryCompare(selector, "createNewSelected", true)
+            compare(selector.showCombo, true)
+            compare(selector.choices.length, 1)
+            compare(selector.ready, true)
+        }
+
+        function test_outputSingleHoldingOffersExistingAndCreateNew() {
+            const selector = createTemporaryObject(selectorComponent, root, {
+                "sourceModel": [root.holdingA],
+                "selectionMode": Wallet.ProgramAccountSelector.Output
+            })
+            verify(!!selector, "Component exists")
+            tryCompare(selector, "selectedAccountId", "holding-a")
+            compare(selector.choices.length, 2)
+            compare(selector.createNewSelected, false)
+            compare(selector.ready, true)
+
+            selector.setSelection("", true)
+            compare(selector.selectedAccountId, "")
+            compare(selector.createNewSelected, true)
+            compare(selector.ready, true)
+        }
+
+        function test_outputMultipleHoldingsRequiresDestination() {
+            const selector = createTemporaryObject(selectorComponent, root, {
+                "sourceModel": [root.holdingA, root.holdingB],
+                "selectionMode": Wallet.ProgramAccountSelector.Output
+            })
+            verify(!!selector, "Component exists")
+            tryCompare(selector, "showCombo", true)
+            compare(selector.choices.length, 3)
+            compare(selector.selectedAccountId, "")
+            compare(selector.createNewSelected, false)
+            compare(selector.ready, false)
+        }
+
+        function test_matchesNumericZeroState() {
+            const selector = createTemporaryObject(selectorComponent, root, {
+                "sourceModel": [{
+                    "accountId": "zero-state",
+                    "accountType": "TokenHolding",
+                    "state": { "version": 0 }
+                }],
+                "stateField": "version",
+                "stateValue": 0,
+                "selectionMode": Wallet.ProgramAccountSelector.Input
+            })
+            verify(!!selector, "Component exists")
+            tryCompare(selector, "selectedAccountId", "zero-state")
+            compare(selector.ready, true)
+        }
+    }
+}

--- a/modules/amm/ffi/include/amm_ffi.h
+++ b/modules/amm/ffi/include/amm_ffi.h
@@ -44,6 +44,8 @@ char *amm_liquidity_quote(const char *request_json);
 
 char *amm_create_pool_plan(const char *request_json);
 
+char *amm_token_holdings(const char *request_json);
+
 char *amm_program_id(const char *request_json);
 
 /**

--- a/modules/amm/ffi/include/amm_ffi.h
+++ b/modules/amm/ffi/include/amm_ffi.h
@@ -44,6 +44,10 @@ char *amm_liquidity_quote(const char *request_json);
 
 char *amm_create_pool_plan(const char *request_json);
 
+char *amm_add_liquidity_quote(const char *request_json);
+
+char *amm_add_liquidity_plan(const char *request_json);
+
 char *amm_token_holdings(const char *request_json);
 
 char *amm_program_id(const char *request_json);

--- a/modules/amm/ffi/include/amm_ffi.h
+++ b/modules/amm/ffi/include/amm_ffi.h
@@ -40,6 +40,10 @@ char *amm_swap_exact_in_plan(const char *request_json);
 
 char *amm_swap_exact_out_plan(const char *request_json);
 
+char *amm_liquidity_quote(const char *request_json);
+
+char *amm_create_pool_plan(const char *request_json);
+
 char *amm_program_id(const char *request_json);
 
 /**

--- a/modules/amm/ffi/src/api/liquidity.rs
+++ b/modules/amm/ffi/src/api/liquidity.rs
@@ -11,12 +11,16 @@
 //! existence before calling; a stale preview or a raced create just reverts on the
 //! guest's `assert pool uninitialized`.
 
-use amm_core::{isqrt_product, spot_price_q64_64, MINIMUM_LIQUIDITY};
+use amm_core::{
+    isqrt_product, mul_div_floor, spot_price_q64_64, PoolDefinition, MINIMUM_LIQUIDITY,
+};
+use nssa_core::account::AccountId;
 use serde_json::{json, Value};
 
 use super::{
     pair::{derive_pair, is_canonical_pair},
-    CreatePoolPlanRequest, LiquidityQuoteRequest,
+    AddLiquidityPlanRequest, AddLiquidityQuoteRequest, CreatePoolPlanRequest,
+    LiquidityQuoteRequest,
 };
 use crate::account::{account_id_from_hex, account_id_hex, parse_program_id};
 
@@ -40,6 +44,42 @@ fn parse_u64(value: &str, label: &str) -> Result<u64, String> {
     value
         .parse::<u64>()
         .map_err(|error| format!("invalid {label}: {error}"))
+}
+
+/// Canonicalizes a token pair and moves each token's paired `(amount, holding)` with it, so
+/// the returned `a` side is the canonical token-a — lining up with `derive_pair`'s canonical
+/// `vault_a`. The guest derives `vault_a` from `user_holding_a`'s definition and debits
+/// `amount_a` into it, so the `(token, amount, holding)` triple must stay together (see
+/// `create_pool_plan`). Shared by the create and add plans.
+fn canonical_triples(
+    token_a: AccountId,
+    token_b: AccountId,
+    amount_a: u128,
+    amount_b: u128,
+    holding_a: AccountId,
+    holding_b: AccountId,
+) -> (AccountId, AccountId, u128, u128, AccountId, AccountId) {
+    if is_canonical_pair(token_a, token_b) {
+        (token_a, token_b, amount_a, amount_b, holding_a, holding_b)
+    } else {
+        (token_b, token_a, amount_b, amount_a, holding_b, holding_a)
+    }
+}
+
+/// The tx-submission envelope shared by the create and add plans: the fixed IDL account ids
+/// as hex, their signer flags, and the risc0-encoded instruction words.
+fn plan_response(
+    program_id: &str,
+    account_ids: impl IntoIterator<Item = AccountId>,
+    signing_requirements: &[bool],
+    instruction: Vec<u32>,
+) -> Value {
+    json!({
+        "programId": program_id,
+        "accountIds": account_ids.into_iter().map(account_id_hex).collect::<Vec<_>>(),
+        "signingRequirements": signing_requirements,
+        "instruction": instruction,
+    })
 }
 
 /// Prices a create-pool deposit: the LP the creator receives and the opening price.
@@ -116,13 +156,8 @@ pub(super) fn create_pool_plan(request: CreatePoolPlanRequest) -> Result<Value, 
     // Canonical orientation: (token, amount, holding) all move together, so user_a is
     // the canonical token-a holding and canonical_amount_a its deposit — matching the
     // canonical vault_a derive_pair returns (see the doc comment).
-    let reversed = !is_canonical_pair(token_a, token_b);
     let (canonical_a, canonical_b, canonical_amount_a, canonical_amount_b, user_a, user_b) =
-        if reversed {
-            (token_b, token_a, amount_b, amount_a, holding_b, holding_a)
-        } else {
-            (token_a, token_b, amount_a, amount_b, holding_a, holding_b)
-        };
+        canonical_triples(token_a, token_b, amount_a, amount_b, holding_a, holding_b);
 
     let Ok(pair) = derive_pair(amm_program, canonical_a, canonical_b, &request.config) else {
         return Err(String::from("config_unavailable"));
@@ -154,12 +189,182 @@ pub(super) fn create_pool_plan(request: CreatePoolPlanRequest) -> Result<Value, 
         false, false, false, false, false, false, true, true, true, false, false,
     ];
 
+    Ok(plan_response(
+        &request.amm_program_id,
+        account_ids,
+        &signing_requirements,
+        instruction,
+    ))
+}
+
+/// Prices an `AddLiquidity` into an existing pool. Mirrors the swap quotes: decode the
+/// pool from `pool_data` (absent / undecodable / zero-supply ⇒ `no_pool`), orient the
+/// caller's max amounts to the pool's canonical `(a, b)` order, then run the guest's exact
+/// proportional-deposit math (`amm_program::add::add_liquidity`): the ideal→actual clamp
+/// and `delta_lp = min(supply·actual_a/reserve_a, supply·actual_b/reserve_b)`. Returns the
+/// same shape as the create quote minus the create-only locked LP: the actual ratio-matched
+/// deposits (display order), the LP minted, and the pool's spot price (`priceRaw`, token B
+/// per token A in display order). The slippage floor is applied at submit, not here — the
+/// quote is a pure preview like create. Errors: `same_token_pair`, `no_pool`,
+/// `pair_mismatch` (the pool isn't for this pair), bad amounts (`amount_required`,
+/// `invalid_raw_amount`, `amount_must_be_positive`), `amount_too_low` (the deposit rounds
+/// to zero LP — nothing to mint).
+pub(super) fn add_liquidity_quote(request: AddLiquidityQuoteRequest) -> Result<Value, String> {
+    let token_a = account_id_from_hex(&request.token_a_id, "token A id")?;
+    let token_b = account_id_from_hex(&request.token_b_id, "token B id")?;
+    if token_a == token_b {
+        return Err(String::from("same_token_pair"));
+    }
+    let max_a = positive_amount(Some(&request.max_amount_a_raw))?;
+    let max_b = positive_amount(Some(&request.max_amount_b_raw))?;
+
+    // Decode the pool; absent / undecodable / empty ⇒ nothing to add to.
+    let pool = hex::decode(&request.pool_data)
+        .ok()
+        .and_then(|bytes| borsh::from_slice::<PoolDefinition>(&bytes).ok())
+        .filter(|pool| pool.liquidity_pool_supply != 0)
+        .ok_or_else(|| String::from("no_pool"))?;
+
+    // Orient the caller's (display) max amounts to the pool's canonical (a, b) order so
+    // the math lines up with the guest; `reversed` also flips the results back to display.
+    let reversed = if token_a == pool.definition_token_a_id && token_b == pool.definition_token_b_id
+    {
+        false
+    } else if token_a == pool.definition_token_b_id && token_b == pool.definition_token_a_id {
+        true
+    } else {
+        return Err(String::from("pair_mismatch"));
+    };
+    if pool.reserve_a == 0 || pool.reserve_b == 0 {
+        return Err(String::from("no_pool"));
+    }
+    let (max_canonical_a, max_canonical_b) = if reversed {
+        (max_b, max_a)
+    } else {
+        (max_a, max_b)
+    };
+
+    // Guest math (amm_program::add::add_liquidity): proportional deposit clamped to the
+    // caller's maxes, then the LP minted for the smaller side.
+    let ideal_a = mul_div_floor(pool.reserve_a, max_canonical_b, pool.reserve_b);
+    let ideal_b = mul_div_floor(pool.reserve_b, max_canonical_a, pool.reserve_a);
+    let actual_a = ideal_a.min(max_canonical_a);
+    let actual_b = ideal_b.min(max_canonical_b);
+    let delta_lp = std::cmp::min(
+        mul_div_floor(pool.liquidity_pool_supply, actual_a, pool.reserve_a),
+        mul_div_floor(pool.liquidity_pool_supply, actual_b, pool.reserve_b),
+    );
+    if actual_a == 0 || actual_b == 0 || delta_lp == 0 {
+        return Err(String::from("amount_too_low"));
+    }
+
+    // Back to display order for the response; the price uses the display-oriented reserves.
+    let (display_a, display_b) = if reversed {
+        (actual_b, actual_a)
+    } else {
+        (actual_a, actual_b)
+    };
+    let (reserve_display_a, reserve_display_b) = if reversed {
+        (pool.reserve_b, pool.reserve_a)
+    } else {
+        (pool.reserve_a, pool.reserve_b)
+    };
+    let price = spot_price_q64_64(reserve_display_a, reserve_display_b);
+
     Ok(json!({
-        "programId": request.amm_program_id,
-        "accountIds": account_ids.into_iter().map(account_id_hex).collect::<Vec<_>>(),
-        "signingRequirements": signing_requirements,
-        "instruction": instruction,
+        "amountARaw": display_a.to_string(),
+        "amountBRaw": display_b.to_string(),
+        "expectedLpRaw": delta_lp.to_string(),
+        "priceRaw": price.to_string(),
     }))
+}
+
+/// Builds the `AddLiquidity` submission for an existing pool. Same canonicalization as
+/// `create_pool_plan` — the `(token, max_amount, holding)` triples move together so `user_a`
+/// / `max_canonical_a` line up with the pool's canonical `vault_a`. Vaults and the LP
+/// definition come from the pool's STORED ids (`pool_data`), which the guest asserts against
+/// (like the swap plans). Emits the fixed 10-account IDL order with only the three user
+/// holdings (a, b, LP) signing. `min_amount_liquidity` is the caller's slippage floor and
+/// must be positive (the guest rejects a zero). Recoverable failures fail closed as `Err`
+/// (`same_token_pair`, `config_unavailable`, `no_pool`, bad amounts).
+pub(super) fn add_liquidity_plan(request: AddLiquidityPlanRequest) -> Result<Value, String> {
+    let amm_program = parse_program_id(&request.amm_program_id)?;
+    let token_a = account_id_from_hex(&request.token_a_id, "token A id")?;
+    let token_b = account_id_from_hex(&request.token_b_id, "token B id")?;
+    if token_a == token_b {
+        return Err(String::from("same_token_pair"));
+    }
+    let holding_a = account_id_from_hex(&request.user_holding_a_id, "user holding A id")?;
+    let holding_b = account_id_from_hex(&request.user_holding_b_id, "user holding B id")?;
+    let user_lp = account_id_from_hex(&request.user_holding_lp_id, "user LP holding id")?;
+
+    let max_a = positive_amount(Some(&request.max_amount_a_raw))?;
+    let max_b = positive_amount(Some(&request.max_amount_b_raw))?;
+    let min_lp = positive_amount(Some(&request.min_lp_raw))?;
+    let deadline = parse_u64(&request.deadline_ms, "deadlineMs")?;
+
+    // config / pool / current_tick / clock are order-independent PDAs, so derive_pair takes the
+    // tokens in the caller's order. (Its canonical vaults are unused here — the guest asserts the
+    // vaults against the pool's stored ids, taken below.)
+    let Ok(pair) = derive_pair(amm_program, token_a, token_b, &request.config) else {
+        return Err(String::from("config_unavailable"));
+    };
+
+    // Vaults + LP definition come from the pool's stored ids (the guest asserts against them).
+    let Some(pool) = hex::decode(&request.pool_data)
+        .ok()
+        .and_then(|bytes| borsh::from_slice::<PoolDefinition>(&bytes).ok())
+    else {
+        return Err(String::from("no_pool"));
+    };
+
+    // Orient (max amount, holding) to the pool's STORED (definition_token_a_id,
+    // definition_token_b_id) order — NOT is_canonical_pair. The guest transfers user_holding_a
+    // into vault_a (== pool.vault_a_id, which holds definition_token_a_id), so user_a / max_pool_a
+    // must be that token's holding / cap. A pool created outside the FFI (e.g. a non-canonical
+    // `spel new-definition`) can store the opposite order, so keying off is_canonical_pair would
+    // send a holding into the wrong vault and the token program rejects the transfer on a
+    // sender/recipient definition mismatch.
+    let (max_pool_a, max_pool_b, user_a, user_b) =
+        if token_a == pool.definition_token_a_id && token_b == pool.definition_token_b_id {
+            (max_a, max_b, holding_a, holding_b)
+        } else if token_a == pool.definition_token_b_id && token_b == pool.definition_token_a_id {
+            (max_b, max_a, holding_b, holding_a)
+        } else {
+            return Err(String::from("pair_mismatch"));
+        };
+
+    let instruction = risc0_zkvm::serde::to_vec(&amm_core::Instruction::AddLiquidity {
+        min_amount_liquidity: min_lp,
+        max_amount_to_add_token_a: max_pool_a,
+        max_amount_to_add_token_b: max_pool_b,
+        deadline,
+    })
+    .map_err(|error| format!("instruction serialization failed: {error}"))?;
+
+    // Fixed IDL account order for AddLiquidity; only the user holdings (a, b, LP) sign.
+    let account_ids = [
+        pair.config,
+        pair.pool,
+        pool.vault_a_id,
+        pool.vault_b_id,
+        pool.liquidity_pool_id,
+        user_a,
+        user_b,
+        user_lp,
+        pair.current_tick,
+        pair.clock,
+    ];
+    let signing_requirements = [
+        false, false, false, false, false, true, true, true, false, false,
+    ];
+
+    Ok(plan_response(
+        &request.amm_program_id,
+        account_ids,
+        &signing_requirements,
+        instruction,
+    ))
 }
 
 #[cfg(test)]
@@ -355,5 +560,269 @@ mod tests {
             user_holding_lp_id: account_id_hex(token),
         });
         assert_eq!(value, Err(String::from("same_token_pair")));
+    }
+
+    fn pool_hex(pool: &PoolDefinition) -> String {
+        hex::encode(borsh::to_vec(pool).unwrap())
+    }
+
+    #[test]
+    fn add_quote_prices_via_guest_formula_and_orients() {
+        let def_a = AccountId::new([0xAA; 32]);
+        let def_b = AccountId::new([0xBB; 32]);
+        let pool = PoolDefinition {
+            definition_token_a_id: def_a,
+            definition_token_b_id: def_b,
+            liquidity_pool_supply: 1_000_000,
+            reserve_a: 1_000_000,
+            reserve_b: 2_000_000,
+            fees: 30,
+            ..Default::default()
+        };
+
+        // Display == canonical. maxB is generous, so token A's cap binds and token B is
+        // ratio-matched down to 20_000 (proving the ideal→actual clamp).
+        let ab = add_liquidity_quote(AddLiquidityQuoteRequest {
+            token_a_id: account_id_hex(def_a),
+            token_b_id: account_id_hex(def_b),
+            max_amount_a_raw: String::from("10000"),
+            max_amount_b_raw: String::from("100000"),
+            pool_data: pool_hex(&pool),
+        })
+        .unwrap();
+        assert_eq!(ab["amountARaw"], "10000");
+        assert_eq!(ab["amountBRaw"], "20000");
+        assert_eq!(ab["expectedLpRaw"], "10000");
+        assert_eq!(
+            ab["priceRaw"],
+            spot_price_q64_64(1_000_000, 2_000_000).to_string()
+        );
+        // Shape parity with create, minus the create-only locked LP and with priceRaw.
+        assert!(ab.get("lockedLpRaw").is_none());
+        assert!(ab.get("initialPriceRaw").is_none());
+
+        // Reverse display order: the actual amounts and the price flip to display order.
+        let ba = add_liquidity_quote(AddLiquidityQuoteRequest {
+            token_a_id: account_id_hex(def_b),
+            token_b_id: account_id_hex(def_a),
+            max_amount_a_raw: String::from("100000"),
+            max_amount_b_raw: String::from("10000"),
+            pool_data: pool_hex(&pool),
+        })
+        .unwrap();
+        assert_eq!(ba["amountARaw"], "20000"); // display token def_b side
+        assert_eq!(ba["amountBRaw"], "10000"); // display token def_a side
+        assert_eq!(ba["expectedLpRaw"], "10000");
+        assert_eq!(
+            ba["priceRaw"],
+            spot_price_q64_64(2_000_000, 1_000_000).to_string()
+        );
+    }
+
+    #[test]
+    fn add_quote_rejects_no_pool_mismatch_and_tiny_deposits() {
+        let def_a = AccountId::new([0xAA; 32]);
+        let def_b = AccountId::new([0xBB; 32]);
+        let pool = PoolDefinition {
+            definition_token_a_id: def_a,
+            definition_token_b_id: def_b,
+            liquidity_pool_supply: 1_000_000,
+            reserve_a: 1_000_000,
+            reserve_b: 2_000_000,
+            fees: 30,
+            ..Default::default()
+        };
+        let req =
+            |token_a: AccountId, token_b: AccountId, max_a: &str, max_b: &str, data: String| {
+                AddLiquidityQuoteRequest {
+                    token_a_id: account_id_hex(token_a),
+                    token_b_id: account_id_hex(token_b),
+                    max_amount_a_raw: max_a.into(),
+                    max_amount_b_raw: max_b.into(),
+                    pool_data: data,
+                }
+            };
+
+        // Same token pair.
+        assert_eq!(
+            add_liquidity_quote(req(def_a, def_a, "1", "1", pool_hex(&pool))),
+            Err(String::from("same_token_pair"))
+        );
+        // Empty / undecodable pool data.
+        assert_eq!(
+            add_liquidity_quote(req(def_a, def_b, "1", "1", String::new())),
+            Err(String::from("no_pool"))
+        );
+        // Zero-supply pool.
+        let empty = PoolDefinition {
+            definition_token_a_id: def_a,
+            definition_token_b_id: def_b,
+            liquidity_pool_supply: 0,
+            ..Default::default()
+        };
+        assert_eq!(
+            add_liquidity_quote(req(def_a, def_b, "1", "1", pool_hex(&empty))),
+            Err(String::from("no_pool"))
+        );
+        // A decoded pool that isn't for this pair.
+        let other = AccountId::new([0xCC; 32]);
+        assert_eq!(
+            add_liquidity_quote(req(def_a, other, "1", "1", pool_hex(&pool))),
+            Err(String::from("pair_mismatch"))
+        );
+        // Deposits so small the minted LP rounds to zero.
+        assert_eq!(
+            add_liquidity_quote(req(def_a, def_b, "1", "1", pool_hex(&pool))),
+            Err(String::from("amount_too_low"))
+        );
+    }
+
+    #[test]
+    fn add_plan_orients_holdings_to_the_pools_stored_order() {
+        let program = "00".repeat(32);
+        let amm = parse_program_id(&program).unwrap();
+
+        // token_b is is_canonical_pair's "canonical a" (larger id), but the pool was created in
+        // the OPPOSITE order — definition_token_a_id = token_a — as a pool created outside the
+        // FFI can be (e.g. the testnet setup's `spel new-definition`). The plan must follow the
+        // POOL's stored order, NOT is_canonical_pair, or a holding lands in the wrong vault and
+        // the token program rejects the transfer on a sender/recipient definition mismatch.
+        let token_a = AccountId::new([0x11; 32]);
+        let token_b = AccountId::new([0x22; 32]);
+        assert!(!is_canonical_pair(token_a, token_b)); // is_canonical_pair's canonical-a is token_b
+
+        let vault_a = AccountId::new([0xA1; 32]); // vault for token_a
+        let vault_b = AccountId::new([0xB1; 32]); // vault for token_b
+        let lp_def = AccountId::new([0xCC; 32]);
+        let pool = PoolDefinition {
+            definition_token_a_id: token_a, // stored NON-canonically (token_a first)
+            definition_token_b_id: token_b,
+            vault_a_id: vault_a,
+            vault_b_id: vault_b,
+            liquidity_pool_id: lp_def,
+            liquidity_pool_supply: 1_000_000,
+            reserve_a: 1_000_000,
+            reserve_b: 2_000_000,
+            fees: 30,
+        };
+
+        let holding_a = AccountId::new([0x0A; 32]); // token_a holding
+        let holding_b = AccountId::new([0x0B; 32]); // token_b holding
+        let lp = AccountId::new([0x0C; 32]);
+
+        // Run the plan for a caller ordering; returns (accountIds, instruction words).
+        let run = |ta: String, tb: String, ma: &str, mb: &str, ha: String, hb: String| {
+            let value = add_liquidity_plan(AddLiquidityPlanRequest {
+                amm_program_id: program.clone(),
+                config: valid_config(amm),
+                token_a_id: ta,
+                token_b_id: tb,
+                max_amount_a_raw: ma.to_string(),
+                max_amount_b_raw: mb.to_string(),
+                min_lp_raw: String::from("500"),
+                deadline_ms: String::from("1000"),
+                user_holding_a_id: ha,
+                user_holding_b_id: hb,
+                user_holding_lp_id: account_id_hex(lp),
+                pool_data: pool_hex(&pool),
+            })
+            .unwrap();
+            let ids = value["accountIds"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|v| v.as_str().unwrap().to_string())
+                .collect::<Vec<String>>();
+            (ids, value["instruction"].clone())
+        };
+
+        // The instruction the guest must receive: token_a's cap into vault_a (token_a), token_b's
+        // cap into vault_b — regardless of the caller's argument order.
+        let expected_instruction = {
+            let words = risc0_zkvm::serde::to_vec(&amm_core::Instruction::AddLiquidity {
+                min_amount_liquidity: 500,
+                max_amount_to_add_token_a: 1_000_000, // token_a's cap
+                max_amount_to_add_token_b: 4_000_000, // token_b's cap
+                deadline: 1_000,
+            })
+            .unwrap();
+            serde_json::json!(words.iter().map(|w| u64::from(*w)).collect::<Vec<u64>>())
+        };
+        let assert_aligned = |ids: &[String], instruction: &serde_json::Value| {
+            assert_eq!(ids[0], account_id_hex(compute_config_pda(amm)));
+            assert_eq!(
+                ids[1],
+                account_id_hex(compute_pool_pda(amm, token_a, token_b))
+            );
+            assert_eq!(ids[2], account_id_hex(vault_a));
+            assert_eq!(ids[3], account_id_hex(vault_b));
+            assert_eq!(ids[4], account_id_hex(lp_def));
+            // user_holding_a is token_a's holding — the token vault_a holds — NOT the
+            // is_canonical_pair canonical-a (token_b) holding.
+            assert_eq!(ids[5], account_id_hex(holding_a));
+            assert_eq!(ids[6], account_id_hex(holding_b));
+            assert_eq!(ids[7], account_id_hex(lp));
+            assert_eq!(instruction, &expected_instruction);
+        };
+
+        // Caller order == the pool's stored order → NO swap (is_canonical_pair WOULD swap here).
+        let (ids, instruction) = run(
+            account_id_hex(token_a),
+            account_id_hex(token_b),
+            "1000000",
+            "4000000",
+            account_id_hex(holding_a),
+            account_id_hex(holding_b),
+        );
+        assert_aligned(&ids, &instruction);
+
+        // Caller order reversed vs the pool → SWAP, so user_a stays token_a's (vault_a's) holding
+        // and each cap follows its token.
+        let (ids, instruction) = run(
+            account_id_hex(token_b),
+            account_id_hex(token_a),
+            "4000000",
+            "1000000",
+            account_id_hex(holding_b),
+            account_id_hex(holding_a),
+        );
+        assert_aligned(&ids, &instruction);
+    }
+
+    #[test]
+    fn add_plan_fails_closed() {
+        let token = AccountId::new([0xAA; 32]);
+        let other = AccountId::new([0xBB; 32]);
+        let base =
+            |token_a: AccountId, token_b: AccountId, pool_data: String| AddLiquidityPlanRequest {
+                amm_program_id: "00".repeat(32),
+                config: read_failed(),
+                token_a_id: account_id_hex(token_a),
+                token_b_id: account_id_hex(token_b),
+                max_amount_a_raw: String::from("1"),
+                max_amount_b_raw: String::from("1"),
+                min_lp_raw: String::from("1"),
+                deadline_ms: String::from("1"),
+                user_holding_a_id: account_id_hex(token_a),
+                user_holding_b_id: account_id_hex(token_b),
+                user_holding_lp_id: account_id_hex(token_a),
+                pool_data,
+            };
+
+        // Same token pair — rejected before any config/pool work.
+        assert_eq!(
+            add_liquidity_plan(base(token, token, String::new())),
+            Err(String::from("same_token_pair"))
+        );
+        // Unavailable config (read_failed) surfaces before the pool decode.
+        assert_eq!(
+            add_liquidity_plan(base(token, other, String::new())),
+            Err(String::from("config_unavailable"))
+        );
+        // Valid config but no pool data → no_pool (decode happens after derive_pair).
+        let amm = parse_program_id(&"00".repeat(32)).unwrap();
+        let mut no_pool = base(token, other, String::new());
+        no_pool.config = valid_config(amm);
+        assert_eq!(add_liquidity_plan(no_pool), Err(String::from("no_pool")));
     }
 }

--- a/modules/amm/ffi/src/api/liquidity.rs
+++ b/modules/amm/ffi/src/api/liquidity.rs
@@ -1,0 +1,359 @@
+//! Liquidity operations — pool-creation quoting and the `NewDefinition` submission
+//! plan. Same lean, transport-independent pattern as `swap.rs`: pure functions
+//! returning JSON `Value`, and the token pair canonicalized server-side so callers
+//! keep no ordering logic.
+//!
+//! `liquidity_quote` is a **pure create-pool preview**: a function of the caller's
+//! own inputs (the two deposit amounts) with no chain reads and no commitment
+//! — it prices the opening LP and price via the same `amm_core` primitives the guest
+//! runs (`isqrt_product`, `MINIMUM_LIQUIDITY`, `spot_price_q64_64`), so the preview
+//! equals what `new_definition` mints. The caller decides create-vs-add by pool
+//! existence before calling; a stale preview or a raced create just reverts on the
+//! guest's `assert pool uninitialized`.
+
+use amm_core::{isqrt_product, spot_price_q64_64, MINIMUM_LIQUIDITY};
+use serde_json::{json, Value};
+
+use super::{
+    pair::{derive_pair, is_canonical_pair},
+    CreatePoolPlanRequest, LiquidityQuoteRequest,
+};
+use crate::account::{account_id_from_hex, account_id_hex, parse_program_id};
+
+/// Parses a required, strictly-positive base-unit amount. Empty / non-digit /
+/// zero inputs surface as stable codes so the UI can flag the offending field.
+fn positive_amount(value: Option<&str>) -> Result<u128, String> {
+    let value = value
+        .filter(|raw| !raw.is_empty())
+        .ok_or("amount_required")?;
+    if !value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(String::from("invalid_raw_amount"));
+    }
+    let amount = value.parse::<u128>().map_err(|_| "invalid_raw_amount")?;
+    if amount == 0 {
+        return Err(String::from("amount_must_be_positive"));
+    }
+    Ok(amount)
+}
+
+fn parse_u64(value: &str, label: &str) -> Result<u64, String> {
+    value
+        .parse::<u64>()
+        .map_err(|error| format!("invalid {label}: {error}"))
+}
+
+/// Prices a create-pool deposit: the LP the creator receives and the opening price.
+///
+/// Pure — no chain reads. The fee tier is not needed: it is not part of the pool PDA
+/// (`compute_pool_pda_seed` hashes only the pair) and does not enter the pricing —
+/// only the two deposit amounts do. `expected_lp = floor(sqrt(a*b)) - MINIMUM_LIQUIDITY`
+/// (the post-permanent-lock remainder the guest mints to the creator); `initialPriceRaw`
+/// is the `Q64.64` display price (token B per token A, in the caller's order). The LP
+/// figure is orientation-independent (the product is symmetric); the price follows the
+/// display order. Errors are stable short codes: `same_token_pair`, `amount_required`,
+/// `invalid_raw_amount`, `amount_must_be_positive`, `amount_too_low` (deposits too small
+/// to clear the locked minimum — the pool can't open).
+pub(super) fn liquidity_quote(request: LiquidityQuoteRequest) -> Result<Value, String> {
+    let token_a = account_id_from_hex(&request.token_a_id, "token A id")?;
+    let token_b = account_id_from_hex(&request.token_b_id, "token B id")?;
+    if token_a == token_b {
+        return Err(String::from("same_token_pair"));
+    }
+
+    let amount_a = positive_amount(request.amount_a_raw.as_deref())?;
+    let amount_b = positive_amount(request.amount_b_raw.as_deref())?;
+
+    // LP math (shared with the guest's new_definition via amm_core): the initial LP
+    // must clear the permanently-locked minimum before the creator receives any.
+    let initial_lp = isqrt_product(amount_a, amount_b);
+    let expected_lp = initial_lp
+        .checked_sub(MINIMUM_LIQUIDITY)
+        .filter(|user_lp| *user_lp > 0)
+        .ok_or("amount_too_low")?;
+    // Display-order price: token B per token A (the caller's orientation).
+    let initial_price = spot_price_q64_64(amount_a, amount_b);
+
+    Ok(json!({
+        "amountARaw": amount_a.to_string(),
+        "amountBRaw": amount_b.to_string(),
+        "expectedLpRaw": expected_lp.to_string(),
+        "lockedLpRaw": MINIMUM_LIQUIDITY.to_string(),
+        "initialPriceRaw": initial_price.to_string(),
+    }))
+}
+
+/// Builds the `NewDefinition` submission for creating a pool.
+///
+/// The pool PDA is order-independent (`compute_pool_pda_seed` sorts the pair
+/// internally), but `derive_pair` yields the vaults / current-tick in **canonical**
+/// order (`vault_a` = the larger token id's vault). The guest, in turn, derives
+/// `vault_a` from `user_holding_a`'s definition and transfers `token_a_amount` out
+/// of it — so the `(vault_a, user_holding_a, token_a_amount)` triple must all name
+/// the same token or balances land in the wrong vault. This op therefore
+/// canonicalizes the pair and moves its amounts / user holdings **as one unit**, so
+/// `user_a` is the canonical token-a holding, `canonical_amount_a` its deposit, and
+/// `pair.vault_a` its vault. Returns the fixed 11-account IDL order with only the
+/// three user holdings (a, b, LP) signing. Recoverable failures fail closed as `Err`
+/// (`same_token_pair`, `config_unavailable`, bad amounts) so the caller never
+/// submits an empty plan.
+pub(super) fn create_pool_plan(request: CreatePoolPlanRequest) -> Result<Value, String> {
+    let amm_program = parse_program_id(&request.amm_program_id)?;
+    let token_a = account_id_from_hex(&request.token_a_id, "token A id")?;
+    let token_b = account_id_from_hex(&request.token_b_id, "token B id")?;
+    if token_a == token_b {
+        return Err(String::from("same_token_pair"));
+    }
+    let holding_a = account_id_from_hex(&request.user_holding_a_id, "user holding A id")?;
+    let holding_b = account_id_from_hex(&request.user_holding_b_id, "user holding B id")?;
+    let user_lp = account_id_from_hex(&request.user_holding_lp_id, "user LP holding id")?;
+
+    let amount_a = positive_amount(request.amount_a_raw.as_deref())?;
+    let amount_b = positive_amount(request.amount_b_raw.as_deref())?;
+    if !amm_core::is_supported_fee_tier(u128::from(request.fee_bps)) {
+        return Err(String::from("invalid_fee_tier"));
+    }
+    let deadline = parse_u64(&request.deadline_ms, "deadlineMs")?;
+    // Canonical orientation: (token, amount, holding) all move together, so user_a is
+    // the canonical token-a holding and canonical_amount_a its deposit — matching the
+    // canonical vault_a derive_pair returns (see the doc comment).
+    let reversed = !is_canonical_pair(token_a, token_b);
+    let (canonical_a, canonical_b, canonical_amount_a, canonical_amount_b, user_a, user_b) =
+        if reversed {
+            (token_b, token_a, amount_b, amount_a, holding_b, holding_a)
+        } else {
+            (token_a, token_b, amount_a, amount_b, holding_a, holding_b)
+        };
+
+    let Ok(pair) = derive_pair(amm_program, canonical_a, canonical_b, &request.config) else {
+        return Err(String::from("config_unavailable"));
+    };
+
+    let instruction = risc0_zkvm::serde::to_vec(&amm_core::Instruction::NewDefinition {
+        token_a_amount: canonical_amount_a,
+        token_b_amount: canonical_amount_b,
+        fees: u128::from(request.fee_bps),
+        deadline,
+    })
+    .map_err(|error| format!("instruction serialization failed: {error}"))?;
+
+    // Fixed IDL account order for NewDefinition; only the user holdings (a, b, LP) sign.
+    let account_ids = [
+        pair.config,
+        pair.pool,
+        pair.vault_a,
+        pair.vault_b,
+        pair.lp_definition,
+        pair.lp_lock_holding,
+        user_a,
+        user_b,
+        user_lp,
+        pair.current_tick,
+        pair.clock,
+    ];
+    let signing_requirements = [
+        false, false, false, false, false, false, true, true, true, false, false,
+    ];
+
+    Ok(json!({
+        "programId": request.amm_program_id,
+        "accountIds": account_ids.into_iter().map(account_id_hex).collect::<Vec<_>>(),
+        "signingRequirements": signing_requirements,
+        "instruction": instruction,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use amm_core::{compute_config_pda, compute_pool_pda, compute_vault_pda, AmmConfig};
+    use nssa_core::account::{Account, AccountId, Data};
+
+    use super::*;
+    use crate::account::{account_read, AccountRead};
+
+    fn quote_request(token_a: AccountId, token_b: AccountId) -> LiquidityQuoteRequest {
+        LiquidityQuoteRequest {
+            token_a_id: account_id_hex(token_a),
+            token_b_id: account_id_hex(token_b),
+            amount_a_raw: Some(String::from("1000000")),
+            amount_b_raw: Some(String::from("4000000")),
+        }
+    }
+
+    fn read_failed() -> AccountRead {
+        AccountRead {
+            id: String::new(),
+            status: String::from("read_failed"),
+            account: None,
+        }
+    }
+
+    /// A valid AMM config account read so `derive_pair` succeeds in plan tests.
+    fn valid_config(amm: nssa_core::program::ProgramId) -> AccountRead {
+        let token_program = parse_program_id(&"01".repeat(32)).unwrap();
+        let twap_program = parse_program_id(&"02".repeat(32)).unwrap();
+        let account = Account {
+            program_owner: amm,
+            data: Data::from(&AmmConfig {
+                token_program_id: token_program,
+                twap_oracle_program_id: twap_program,
+                authority: AccountId::new([0x09; 32]),
+            }),
+            ..Account::default()
+        };
+        account_read(compute_config_pda(amm), &account)
+    }
+
+    #[test]
+    fn create_quote_prices_the_opening() {
+        let token_a = AccountId::new([0xAA; 32]);
+        let token_b = AccountId::new([0xBB; 32]);
+        let value = liquidity_quote(quote_request(token_a, token_b)).unwrap();
+
+        assert_eq!(value["amountARaw"], "1000000");
+        assert_eq!(value["amountBRaw"], "4000000");
+        assert_eq!(value["lockedLpRaw"], MINIMUM_LIQUIDITY.to_string());
+        // initial_lp = isqrt(1_000_000 * 4_000_000) = 2_000_000; creator LP = minus lock.
+        let initial_lp = isqrt_product(1_000_000, 4_000_000);
+        assert_eq!(
+            value["expectedLpRaw"],
+            (initial_lp - MINIMUM_LIQUIDITY).to_string()
+        );
+        assert_eq!(
+            value["initialPriceRaw"],
+            spot_price_q64_64(1_000_000, 4_000_000).to_string()
+        );
+        // Lean preview — no commitment / status / submittability fields.
+        assert!(value.get("quoteHash").is_none());
+        assert!(value.get("canSubmit").is_none());
+        assert!(value.get("poolStatus").is_none());
+    }
+
+    #[test]
+    fn create_quote_lp_is_orientation_independent() {
+        let token_a = AccountId::new([0xAA; 32]);
+        let token_b = AccountId::new([0xBB; 32]);
+        let ab = liquidity_quote(quote_request(token_a, token_b)).unwrap();
+        // Swap display order and the paired amounts: the LP figure is symmetric.
+        let mut ba = quote_request(token_b, token_a);
+        ba.amount_a_raw = Some(String::from("4000000"));
+        ba.amount_b_raw = Some(String::from("1000000"));
+        let ba = liquidity_quote(ba).unwrap();
+        assert_eq!(ab["expectedLpRaw"], ba["expectedLpRaw"]);
+    }
+
+    #[test]
+    fn create_quote_rejects_same_token_and_tiny_amounts() {
+        let token = AccountId::new([0xAA; 32]);
+        assert_eq!(
+            liquidity_quote(quote_request(token, token)),
+            Err(String::from("same_token_pair"))
+        );
+
+        // isqrt(1 * 1) = 1 ≤ MINIMUM_LIQUIDITY ⇒ the pool can't open.
+        let token_b = AccountId::new([0xBB; 32]);
+        let mut tiny = quote_request(token, token_b);
+        tiny.amount_a_raw = Some(String::from("1"));
+        tiny.amount_b_raw = Some(String::from("1"));
+        assert_eq!(liquidity_quote(tiny), Err(String::from("amount_too_low")));
+    }
+
+    #[test]
+    fn create_plan_pairs_each_amount_with_its_canonical_vault() {
+        let program = "00".repeat(32);
+        let amm = parse_program_id(&program).unwrap();
+
+        // Display order is NON-canonical (token_a < token_b), so canonical `a` is the
+        // display `b`. This is the case where a misapplied swap would corrupt balances.
+        let token_a = AccountId::new([0x11; 32]);
+        let token_b = AccountId::new([0x22; 32]);
+        assert!(!is_canonical_pair(token_a, token_b));
+        let (canonical_a, canonical_b) = (token_b, token_a);
+
+        let holding_a = AccountId::new([0x0A; 32]); // holds display token_a
+        let holding_b = AccountId::new([0x0B; 32]); // holds display token_b (canonical a)
+        let lp = AccountId::new([0x0C; 32]);
+
+        let value = create_pool_plan(CreatePoolPlanRequest {
+            amm_program_id: program.clone(),
+            config: valid_config(amm),
+            token_a_id: account_id_hex(token_a),
+            token_b_id: account_id_hex(token_b),
+            amount_a_raw: Some(String::from("1000000")), // deposit for display token_a
+            amount_b_raw: Some(String::from("4000000")), // deposit for display token_b
+            fee_bps: 30,
+            deadline_ms: String::from("1000"),
+            user_holding_a_id: account_id_hex(holding_a),
+            user_holding_b_id: account_id_hex(holding_b),
+            user_holding_lp_id: account_id_hex(lp),
+        })
+        .unwrap();
+
+        let ids: Vec<&str> = value["accountIds"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|value| value.as_str().unwrap())
+            .collect();
+        let signers: Vec<bool> = value["signingRequirements"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|value| value.as_bool().unwrap())
+            .collect();
+
+        let pool = compute_pool_pda(amm, canonical_a, canonical_b);
+        assert_eq!(ids[0], account_id_hex(compute_config_pda(amm)));
+        assert_eq!(ids[1], account_id_hex(pool));
+        // Canonical vaults, in canonical order.
+        assert_eq!(
+            ids[2],
+            account_id_hex(compute_vault_pda(amm, pool, canonical_a))
+        );
+        assert_eq!(
+            ids[3],
+            account_id_hex(compute_vault_pda(amm, pool, canonical_b))
+        );
+        // user_holding_a is the CANONICAL token-a holding = display token_b's holding.
+        assert_eq!(ids[6], account_id_hex(holding_b));
+        assert_eq!(ids[7], account_id_hex(holding_a));
+        assert_eq!(ids[8], account_id_hex(lp));
+        assert_eq!(
+            signers,
+            vec![false, false, false, false, false, false, true, true, true, false, false]
+        );
+
+        // The decisive check: the encoded instruction must carry token_a_amount =
+        // 4_000_000 (the deposit into canonical vault_a) — the amount the user entered
+        // for THAT token (display token_b), not display token_a's 1_000_000. Comparing
+        // against the re-encoded expected instruction proves balances follow their
+        // tokens through the swap.
+        let expected = risc0_zkvm::serde::to_vec(&amm_core::Instruction::NewDefinition {
+            token_a_amount: 4_000_000,
+            token_b_amount: 1_000_000,
+            fees: 30,
+            deadline: 1_000,
+        })
+        .unwrap();
+        let expected_words: Vec<u64> = expected.iter().map(|word| u64::from(*word)).collect();
+        assert_eq!(value["instruction"], serde_json::json!(expected_words));
+    }
+
+    #[test]
+    fn create_plan_rejects_same_token() {
+        let token = AccountId::new([0xAA; 32]);
+        let value = create_pool_plan(CreatePoolPlanRequest {
+            amm_program_id: "00".repeat(32),
+            config: read_failed(),
+            token_a_id: account_id_hex(token),
+            token_b_id: account_id_hex(token),
+            amount_a_raw: Some(String::from("1")),
+            amount_b_raw: Some(String::from("1")),
+            fee_bps: 30,
+            deadline_ms: String::from("1"),
+            user_holding_a_id: account_id_hex(token),
+            user_holding_b_id: account_id_hex(token),
+            user_holding_lp_id: account_id_hex(token),
+        });
+        assert_eq!(value, Err(String::from("same_token_pair")));
+    }
+}

--- a/modules/amm/ffi/src/api/mod.rs
+++ b/modules/amm/ffi/src/api/mod.rs
@@ -7,6 +7,7 @@ mod config;
 mod context;
 mod funding;
 mod holding;
+mod liquidity;
 mod pair;
 mod plan;
 mod position;
@@ -21,10 +22,10 @@ mod tests;
 use std::{error::Error, fmt};
 
 pub use request::{
-    ConfigIdRequest, ContextRequest, PairIdsRequest, PairSnapshot, PlanRequest, PoolIdRequest,
-    PositionRequest, ProgramIdRequest, QuoteRequest, ResolvePoolRequest, SwapExactInPlanRequest,
-    SwapExactInQuoteRequest, SwapExactOutPlanRequest, SwapExactOutQuoteRequest, SwapPairRequest,
-    TokenIdsRequest,
+    ConfigIdRequest, ContextRequest, CreatePoolPlanRequest, LiquidityQuoteRequest, PairIdsRequest,
+    PairSnapshot, PlanRequest, PoolIdRequest, PositionRequest, ProgramIdRequest, QuoteRequest,
+    ResolvePoolRequest, SwapExactInPlanRequest, SwapExactInQuoteRequest, SwapExactOutPlanRequest,
+    SwapExactOutQuoteRequest, SwapPairRequest, TokenIdsRequest,
 };
 use serde_json::Value;
 
@@ -127,6 +128,16 @@ pub fn swap_exact_in_plan(request: SwapExactInPlanRequest) -> AmmResult {
 /// Builds the `SwapExactOutput` wallet submission for a token pair.
 pub fn swap_exact_out_plan(request: SwapExactOutPlanRequest) -> AmmResult {
     swap::swap_exact_out_plan(request).map_err(Into::into)
+}
+
+/// Prices a create-pool deposit: the LP the creator receives and the opening price.
+pub fn liquidity_quote(request: LiquidityQuoteRequest) -> AmmResult {
+    liquidity::liquidity_quote(request).map_err(Into::into)
+}
+
+/// Builds the `NewDefinition` submission for creating a pool.
+pub fn create_pool_plan(request: CreatePoolPlanRequest) -> AmmResult {
+    liquidity::create_pool_plan(request).map_err(Into::into)
 }
 
 /// Derives the AMM `ProgramId` (Image ID) from a deployed program binary.

--- a/modules/amm/ffi/src/api/mod.rs
+++ b/modules/amm/ffi/src/api/mod.rs
@@ -15,6 +15,7 @@ mod quote;
 mod quote_error;
 mod request;
 mod swap;
+mod token_holdings;
 
 #[cfg(test)]
 mod tests;
@@ -25,7 +26,7 @@ pub use request::{
     ConfigIdRequest, ContextRequest, CreatePoolPlanRequest, LiquidityQuoteRequest, PairIdsRequest,
     PairSnapshot, PlanRequest, PoolIdRequest, PositionRequest, ProgramIdRequest, QuoteRequest,
     ResolvePoolRequest, SwapExactInPlanRequest, SwapExactInQuoteRequest, SwapExactOutPlanRequest,
-    SwapExactOutQuoteRequest, SwapPairRequest, TokenIdsRequest,
+    SwapExactOutQuoteRequest, SwapPairRequest, TokenHoldingsRequest, TokenIdsRequest,
 };
 use serde_json::Value;
 
@@ -138,6 +139,11 @@ pub fn liquidity_quote(request: LiquidityQuoteRequest) -> AmmResult {
 /// Builds the `NewDefinition` submission for creating a pool.
 pub fn create_pool_plan(request: CreatePoolPlanRequest) -> AmmResult {
     liquidity::create_pool_plan(request).map_err(Into::into)
+}
+
+/// Lists the wallet's fungible token holdings for the account selector.
+pub fn token_holdings(request: TokenHoldingsRequest) -> AmmResult {
+    token_holdings::token_holdings(request).map_err(Into::into)
 }
 
 /// Derives the AMM `ProgramId` (Image ID) from a deployed program binary.

--- a/modules/amm/ffi/src/api/mod.rs
+++ b/modules/amm/ffi/src/api/mod.rs
@@ -23,9 +23,10 @@ mod tests;
 use std::{error::Error, fmt};
 
 pub use request::{
-    ConfigIdRequest, ContextRequest, CreatePoolPlanRequest, LiquidityQuoteRequest, PairIdsRequest,
-    PairSnapshot, PlanRequest, PoolIdRequest, PositionRequest, ProgramIdRequest, QuoteRequest,
-    ResolvePoolRequest, SwapExactInPlanRequest, SwapExactInQuoteRequest, SwapExactOutPlanRequest,
+    AddLiquidityPlanRequest, AddLiquidityQuoteRequest, ConfigIdRequest, ContextRequest,
+    CreatePoolPlanRequest, LiquidityQuoteRequest, PairIdsRequest, PairSnapshot, PlanRequest,
+    PoolIdRequest, PositionRequest, ProgramIdRequest, QuoteRequest, ResolvePoolRequest,
+    SwapExactInPlanRequest, SwapExactInQuoteRequest, SwapExactOutPlanRequest,
     SwapExactOutQuoteRequest, SwapPairRequest, TokenHoldingsRequest, TokenIdsRequest,
 };
 use serde_json::Value;
@@ -139,6 +140,14 @@ pub fn liquidity_quote(request: LiquidityQuoteRequest) -> AmmResult {
 /// Builds the `NewDefinition` submission for creating a pool.
 pub fn create_pool_plan(request: CreatePoolPlanRequest) -> AmmResult {
     liquidity::create_pool_plan(request).map_err(Into::into)
+}
+
+pub fn add_liquidity_quote(request: AddLiquidityQuoteRequest) -> AmmResult {
+    liquidity::add_liquidity_quote(request).map_err(Into::into)
+}
+
+pub fn add_liquidity_plan(request: AddLiquidityPlanRequest) -> AmmResult {
+    liquidity::add_liquidity_plan(request).map_err(Into::into)
 }
 
 /// Lists the wallet's fungible token holdings for the account selector.

--- a/modules/amm/ffi/src/api/request.rs
+++ b/modules/amm/ffi/src/api/request.rs
@@ -137,6 +137,39 @@ pub struct SwapExactOutPlanRequest {
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
+pub struct LiquidityQuoteRequest {
+    pub token_a_id: String,
+    pub token_b_id: String,
+    #[serde(default)]
+    pub amount_a_raw: Option<String>,
+    #[serde(default)]
+    pub amount_b_raw: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CreatePoolPlanRequest {
+    /// Resolved by the module from `AMM_PROGRAM_BIN` (like every id-deriving op) —
+    /// the FFI is stateless and can't read it itself.
+    pub amm_program_id: String,
+    /// AMM config account read — decoded by `derive_pair` for the `twap_oracle_program_id`
+    /// the `current_tick` PDA depends on (same as the swap plan requests).
+    pub config: AccountRead,
+    pub token_a_id: String,
+    pub token_b_id: String,
+    #[serde(default)]
+    pub amount_a_raw: Option<String>,
+    #[serde(default)]
+    pub amount_b_raw: Option<String>,
+    pub fee_bps: u32,
+    pub deadline_ms: String,
+    pub user_holding_a_id: String,
+    pub user_holding_b_id: String,
+    pub user_holding_lp_id: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct ProgramIdRequest {
     pub elf: String,
 }

--- a/modules/amm/ffi/src/api/request.rs
+++ b/modules/amm/ffi/src/api/request.rs
@@ -168,6 +168,43 @@ pub struct CreatePoolPlanRequest {
     pub user_holding_lp_id: String,
 }
 
+/// Prices an `AddLiquidity` into an existing pool — the add counterpart of
+/// `LiquidityQuoteRequest`. The two max amounts are the caller's caps (display order);
+/// `pool_data` is the hex Borsh `PoolDefinition` (empty ⇒ no pool), same as the swap quotes.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AddLiquidityQuoteRequest {
+    pub token_a_id: String,
+    pub token_b_id: String,
+    pub max_amount_a_raw: String,
+    pub max_amount_b_raw: String,
+    pub pool_data: String,
+}
+
+/// Builds the `AddLiquidity` submission — the add counterpart of `CreatePoolPlanRequest`.
+/// `min_lp_raw` is the caller's slippage floor on the LP minted (the guest's
+/// `min_amount_liquidity`, applied at submit like the swap plans' `min_out`); `pool_data`
+/// supplies the stored vault / LP-definition ids the guest asserts against.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AddLiquidityPlanRequest {
+    /// Resolved by the module from `AMM_PROGRAM_BIN` (like every id-deriving op).
+    pub amm_program_id: String,
+    /// AMM config account read — decoded by `derive_pair` for the `twap_oracle_program_id`
+    /// the `current_tick` PDA depends on (same as the swap / create plan requests).
+    pub config: AccountRead,
+    pub token_a_id: String,
+    pub token_b_id: String,
+    pub max_amount_a_raw: String,
+    pub max_amount_b_raw: String,
+    pub min_lp_raw: String,
+    pub deadline_ms: String,
+    pub user_holding_a_id: String,
+    pub user_holding_b_id: String,
+    pub user_holding_lp_id: String,
+    pub pool_data: String,
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct TokenHoldingsRequest {

--- a/modules/amm/ffi/src/api/request.rs
+++ b/modules/amm/ffi/src/api/request.rs
@@ -170,6 +170,17 @@ pub struct CreatePoolPlanRequest {
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
+pub struct TokenHoldingsRequest {
+    pub amm_program_id: String,
+    /// AMM config account read — decoded for the `token_program_id` that identifies
+    /// which wallet accounts are token holdings.
+    pub config: AccountRead,
+    #[serde(default)]
+    pub wallet_accounts: Vec<AccountRead>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct ProgramIdRequest {
     pub elf: String,
 }

--- a/modules/amm/ffi/src/api/token_holdings.rs
+++ b/modules/amm/ffi/src/api/token_holdings.rs
@@ -1,0 +1,132 @@
+//! Lists the wallet's fungible token holdings for the account selector.
+//!
+//! A flat, decoded view of every `TokenHolding` the wallet owns (owned by the
+//! configured token program), each row carrying the id in **both** encodings so
+//! the swap view (hex ids) and the liquidity view (base58 ids) can each filter by
+//! their own token id via the selector's `stateField`. Pure over the wallet reads +
+//! config — no chain access of its own.
+//!
+//! Thin stopgap: token holdings are wallet/token-program data, not AMM data. This
+//! lives here only because `amm_ffi` is the one place wired to decode `TokenHolding`
+//! (via `token_core`); it should move to a dedicated token-program logos module once
+//! one exists.
+
+use serde_json::{json, Value};
+
+use super::{config::load_config, holding::wallet_holdings, TokenHoldingsRequest};
+use crate::account::{account_id_hex, parse_program_id};
+
+pub(super) fn token_holdings(request: TokenHoldingsRequest) -> Result<Value, String> {
+    let amm_program = parse_program_id(&request.amm_program_id)?;
+    let config = load_config(amm_program, &request.config)?;
+    let holdings = wallet_holdings(&request.wallet_accounts, config.token_program_id);
+    let rows = holdings
+        .into_iter()
+        .map(|holding| {
+            json!({
+                "accountId": account_id_hex(holding.id),
+                "accountType": "TokenHolding",
+                // Both encodings: the swap view filters on definitionIdHex, the
+                // liquidity view on the base58 definitionId.
+                "definitionId": holding.definition_id.to_string(),
+                "definitionIdHex": account_id_hex(holding.definition_id),
+                "balanceRaw": holding.balance.to_string(),
+            })
+        })
+        .collect::<Vec<_>>();
+    Ok(json!({ "holdings": rows }))
+}
+
+#[cfg(test)]
+mod tests {
+    use amm_core::{compute_config_pda, AmmConfig};
+    use nssa_core::{
+        account::{Account, AccountId, Data},
+        program::ProgramId,
+    };
+    use token_core::TokenHolding;
+
+    use super::*;
+    use crate::account::{account_read, AccountRead};
+
+    fn token_program() -> ProgramId {
+        parse_program_id(&"01".repeat(32)).unwrap()
+    }
+
+    fn holding_read(id: AccountId, definition: AccountId, balance: u128) -> AccountRead {
+        let account = Account {
+            program_owner: token_program(),
+            data: (&TokenHolding::Fungible {
+                definition_id: definition,
+                balance,
+            })
+                .into(),
+            ..Account::default()
+        };
+        account_read(id, &account)
+    }
+
+    fn config_read(amm: ProgramId) -> AccountRead {
+        let account = Account {
+            program_owner: amm,
+            data: Data::from(&AmmConfig {
+                token_program_id: token_program(),
+                twap_oracle_program_id: parse_program_id(&"02".repeat(32)).unwrap(),
+                authority: AccountId::new([0x09; 32]),
+            }),
+            ..Account::default()
+        };
+        account_read(compute_config_pda(amm), &account)
+    }
+
+    #[test]
+    fn lists_wallet_token_holdings_with_both_id_encodings() {
+        let amm = parse_program_id(&"00".repeat(32)).unwrap();
+        let def = AccountId::new([0xAA; 32]);
+        let holding_id = AccountId::new([0x01; 32]);
+
+        let value = token_holdings(TokenHoldingsRequest {
+            amm_program_id: "00".repeat(32),
+            config: config_read(amm),
+            wallet_accounts: vec![holding_read(holding_id, def, 500)],
+        })
+        .unwrap();
+
+        let rows = value["holdings"].as_array().unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["accountId"], account_id_hex(holding_id));
+        assert_eq!(rows[0]["accountType"], "TokenHolding");
+        assert_eq!(rows[0]["definitionId"], def.to_string());
+        assert_eq!(rows[0]["definitionIdHex"], account_id_hex(def));
+        assert_eq!(rows[0]["balanceRaw"], "500");
+    }
+
+    #[test]
+    fn skips_non_token_accounts_and_fails_closed_on_bad_config() {
+        let amm = parse_program_id(&"00".repeat(32)).unwrap();
+        // A non-token-program account is not a holding.
+        let foreign = Account {
+            program_owner: parse_program_id(&"ee".repeat(32)).unwrap(),
+            ..Account::default()
+        };
+        let value = token_holdings(TokenHoldingsRequest {
+            amm_program_id: "00".repeat(32),
+            config: config_read(amm),
+            wallet_accounts: vec![account_read(AccountId::new([0x02; 32]), &foreign)],
+        })
+        .unwrap();
+        assert!(value["holdings"].as_array().unwrap().is_empty());
+
+        // A read-failed config fails closed as Err.
+        assert!(token_holdings(TokenHoldingsRequest {
+            amm_program_id: "00".repeat(32),
+            config: AccountRead {
+                id: String::new(),
+                status: String::from("read_failed"),
+                account: None,
+            },
+            wallet_accounts: vec![],
+        })
+        .is_err());
+    }
+}

--- a/modules/amm/ffi/src/ffi.rs
+++ b/modules/amm/ffi/src/ffi.rs
@@ -6,10 +6,10 @@ use std::{
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::api::{
-    self, AmmApiError, AmmResult, ConfigIdRequest, ContextRequest, PairIdsRequest, PlanRequest,
-    PoolIdRequest, ProgramIdRequest, QuoteRequest, ResolvePoolRequest, SwapExactInPlanRequest,
-    SwapExactInQuoteRequest, SwapExactOutPlanRequest, SwapExactOutQuoteRequest, SwapPairRequest,
-    TokenIdsRequest,
+    self, AmmApiError, AmmResult, ConfigIdRequest, ContextRequest, CreatePoolPlanRequest,
+    LiquidityQuoteRequest, PairIdsRequest, PlanRequest, PoolIdRequest, ProgramIdRequest,
+    QuoteRequest, ResolvePoolRequest, SwapExactInPlanRequest, SwapExactInQuoteRequest,
+    SwapExactOutPlanRequest, SwapExactOutQuoteRequest, SwapPairRequest, TokenIdsRequest,
 };
 
 #[derive(Serialize)]
@@ -141,6 +141,16 @@ pub extern "C" fn amm_swap_exact_in_plan(request_json: *const c_char) -> *mut c_
 #[unsafe(no_mangle)]
 pub extern "C" fn amm_swap_exact_out_plan(request_json: *const c_char) -> *mut c_char {
     call::<SwapExactOutPlanRequest>(request_json, api::swap_exact_out_plan)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn amm_liquidity_quote(request_json: *const c_char) -> *mut c_char {
+    call::<LiquidityQuoteRequest>(request_json, api::liquidity_quote)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn amm_create_pool_plan(request_json: *const c_char) -> *mut c_char {
+    call::<CreatePoolPlanRequest>(request_json, api::create_pool_plan)
 }
 
 #[unsafe(no_mangle)]

--- a/modules/amm/ffi/src/ffi.rs
+++ b/modules/amm/ffi/src/ffi.rs
@@ -6,11 +6,11 @@ use std::{
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::api::{
-    self, AmmApiError, AmmResult, ConfigIdRequest, ContextRequest, CreatePoolPlanRequest,
-    LiquidityQuoteRequest, PairIdsRequest, PlanRequest, PoolIdRequest, ProgramIdRequest,
-    QuoteRequest, ResolvePoolRequest, SwapExactInPlanRequest, SwapExactInQuoteRequest,
-    SwapExactOutPlanRequest, SwapExactOutQuoteRequest, SwapPairRequest, TokenHoldingsRequest,
-    TokenIdsRequest,
+    self, AddLiquidityPlanRequest, AddLiquidityQuoteRequest, AmmApiError, AmmResult,
+    ConfigIdRequest, ContextRequest, CreatePoolPlanRequest, LiquidityQuoteRequest, PairIdsRequest,
+    PlanRequest, PoolIdRequest, ProgramIdRequest, QuoteRequest, ResolvePoolRequest,
+    SwapExactInPlanRequest, SwapExactInQuoteRequest, SwapExactOutPlanRequest,
+    SwapExactOutQuoteRequest, SwapPairRequest, TokenHoldingsRequest, TokenIdsRequest,
 };
 
 #[derive(Serialize)]
@@ -152,6 +152,16 @@ pub extern "C" fn amm_liquidity_quote(request_json: *const c_char) -> *mut c_cha
 #[unsafe(no_mangle)]
 pub extern "C" fn amm_create_pool_plan(request_json: *const c_char) -> *mut c_char {
     call::<CreatePoolPlanRequest>(request_json, api::create_pool_plan)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn amm_add_liquidity_quote(request_json: *const c_char) -> *mut c_char {
+    call::<AddLiquidityQuoteRequest>(request_json, api::add_liquidity_quote)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn amm_add_liquidity_plan(request_json: *const c_char) -> *mut c_char {
+    call::<AddLiquidityPlanRequest>(request_json, api::add_liquidity_plan)
 }
 
 #[unsafe(no_mangle)]

--- a/modules/amm/ffi/src/ffi.rs
+++ b/modules/amm/ffi/src/ffi.rs
@@ -9,7 +9,8 @@ use crate::api::{
     self, AmmApiError, AmmResult, ConfigIdRequest, ContextRequest, CreatePoolPlanRequest,
     LiquidityQuoteRequest, PairIdsRequest, PlanRequest, PoolIdRequest, ProgramIdRequest,
     QuoteRequest, ResolvePoolRequest, SwapExactInPlanRequest, SwapExactInQuoteRequest,
-    SwapExactOutPlanRequest, SwapExactOutQuoteRequest, SwapPairRequest, TokenIdsRequest,
+    SwapExactOutPlanRequest, SwapExactOutQuoteRequest, SwapPairRequest, TokenHoldingsRequest,
+    TokenIdsRequest,
 };
 
 #[derive(Serialize)]
@@ -151,6 +152,11 @@ pub extern "C" fn amm_liquidity_quote(request_json: *const c_char) -> *mut c_cha
 #[unsafe(no_mangle)]
 pub extern "C" fn amm_create_pool_plan(request_json: *const c_char) -> *mut c_char {
     call::<CreatePoolPlanRequest>(request_json, api::create_pool_plan)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn amm_token_holdings(request_json: *const c_char) -> *mut c_char {
+    call::<TokenHoldingsRequest>(request_json, api::token_holdings)
 }
 
 #[unsafe(no_mangle)]

--- a/modules/amm/ffi/src/lib.rs
+++ b/modules/amm/ffi/src/lib.rs
@@ -6,11 +6,11 @@ mod ffi;
 pub mod api;
 
 pub use api::{
-    config_id, context, pair_ids, plan, pool_id, program_id, quote, resolve_pool,
-    swap_exact_in_plan, swap_exact_in_quote, swap_exact_out_plan, swap_exact_out_quote, swap_pair,
-    token_ids, AccountRead, AmmApiError, AmmResponse, AmmResult, ConfigIdRequest, ContextRequest,
-    PairIdsRequest, PairSnapshot, PlanRequest, PoolIdRequest, PositionRequest, ProgramIdRequest,
-    QuoteRequest, ResolvePoolRequest, SwapExactInPlanRequest, SwapExactInQuoteRequest,
-    SwapExactOutPlanRequest, SwapExactOutQuoteRequest, SwapPairRequest, TokenIdsRequest,
-    WalletAccount,
+    config_id, context, create_pool_plan, liquidity_quote, pair_ids, plan, pool_id, program_id,
+    quote, resolve_pool, swap_exact_in_plan, swap_exact_in_quote, swap_exact_out_plan,
+    swap_exact_out_quote, swap_pair, token_ids, AccountRead, AmmApiError, AmmResponse, AmmResult,
+    ConfigIdRequest, ContextRequest, CreatePoolPlanRequest, LiquidityQuoteRequest, PairIdsRequest,
+    PairSnapshot, PlanRequest, PoolIdRequest, PositionRequest, ProgramIdRequest, QuoteRequest,
+    ResolvePoolRequest, SwapExactInPlanRequest, SwapExactInQuoteRequest, SwapExactOutPlanRequest,
+    SwapExactOutQuoteRequest, SwapPairRequest, TokenIdsRequest, WalletAccount,
 };

--- a/modules/amm/ffi/tests/public_api.rs
+++ b/modules/amm/ffi/tests/public_api.rs
@@ -1,4 +1,7 @@
-use amm_ffi::{config_id, ConfigIdRequest};
+use amm_ffi::{
+    config_id, create_pool_plan, liquidity_quote, AmmResult, ConfigIdRequest,
+    CreatePoolPlanRequest, LiquidityQuoteRequest,
+};
 
 #[test]
 fn direct_rust_api_does_not_require_ffi() {
@@ -9,4 +12,21 @@ fn direct_rust_api_does_not_require_ffi() {
 
     assert_eq!(response["status"], "ok");
     assert!(response["configId"].is_string());
+}
+
+// The create-pool surface must be reachable from the crate root too — Rust callers import from
+// `amm_ffi::`, not `amm_ffi::api`. liquidity_quote is a pure preview, so exercise it directly;
+// create_pool_plan needs chain reads, so a typed reference is enough to pin the re-export.
+#[test]
+fn create_pool_surface_is_reexported_from_crate_root() {
+    let quote = liquidity_quote(LiquidityQuoteRequest {
+        token_a_id: "11".repeat(32),
+        token_b_id: "22".repeat(32),
+        amount_a_raw: Some("1000000".into()),
+        amount_b_raw: Some("4000000".into()),
+    })
+    .expect("a valid pure create-pool quote should succeed");
+    assert_eq!(quote["amountARaw"], "1000000");
+
+    let _plan: fn(CreatePoolPlanRequest) -> AmmResult = create_pool_plan;
 }

--- a/modules/amm/src/amm_module_impl.cpp
+++ b/modules/amm/src/amm_module_impl.cpp
@@ -919,6 +919,37 @@ LogosList AmmModuleImpl::tokenList() {
     return out;
 }
 
+LogosList AmmModuleImpl::tokenHoldings(bool wallet_open) {
+    const std::string amm_program_id = ammProgramId();
+    if (amm_program_id.empty())
+        return LogosList::array();
+
+    // The config gives the token_program_id that identifies which wallet accounts
+    // are token holdings (decoded by the FFI op).
+    const FfiResult configResult =
+        call(amm_config_id, json{{"ammProgramId", amm_program_id}});
+    if (!configResult.ok)
+        return LogosList::array();
+    const json config = readPublicAccount(jStr(configResult.value, "configId"));
+
+    // Fresh wallet read each call — the selector wants current holdings/balances.
+    const json wallet_accounts = walletAccountReads(wallet_open, /*refresh=*/true);
+
+    const FfiResult result = call(amm_token_holdings, json{
+        {"ammProgramId", amm_program_id},
+        {"config", config},
+        {"walletAccounts", wallet_accounts},
+    });
+    if (!result.ok)
+        return LogosList::array();
+
+    LogosList out = LogosList::array();
+    const auto it = result.value.find("holdings");
+    if (it != result.value.end() && it->is_array())
+        for (const auto& holding : *it) out.push_back(holding);
+    return out;
+}
+
 nlohmann::json AmmModuleImpl::buildQuoteInput(const LogosMap& request,
                                               const Network& net,
                                               bool wallet_open,

--- a/modules/amm/src/amm_module_impl.cpp
+++ b/modules/amm/src/amm_module_impl.cpp
@@ -746,6 +746,136 @@ std::string AmmModuleImpl::swapExactOutput(const std::string& def_a_hex,
     return jStr(obj, "tx_hash");
 }
 
+LogosMap AmmModuleImpl::liquidityQuote(const LogosMap& request) {
+    auto error = [](const std::string& err) {
+        return LogosMap{{"status", "error"}, {"error", err}};
+    };
+
+    // Pure preview — no program id / chain reads / fee. Normalize the pair to hex (the
+    // liquidity UI still sources base58 ids from newPositionContext; transitional).
+    const std::string token_a = normalizeAccountId(jStr(request, "tokenAId"));
+    const std::string token_b = normalizeAccountId(jStr(request, "tokenBId"));
+    if (token_a.empty() || token_b.empty())
+        return error("invalid_token_id");
+
+    // amountARaw/amountBRaw arrive as a JSON number (CLI) or decimal string (UI);
+    // coerce to canonical decimal strings (rejects floats — see jsonAmountToDecimal).
+    // If an amount field is present but malformed, return bad_amount; otherwise leave it
+    // out so the FFI returns amount_required.
+    json quoteRequest = {
+        {"tokenAId", token_a},
+        {"tokenBId", token_b},
+    };
+    if (request.contains("amountARaw")) {
+        std::string amount_a_decimal;
+        if (!jsonAmountToDecimal(request.at("amountARaw"), amount_a_decimal))
+            return error("bad_amount");
+        quoteRequest["amountARaw"] = amount_a_decimal;
+    }
+    if (request.contains("amountBRaw")) {
+        std::string amount_b_decimal;
+        if (!jsonAmountToDecimal(request.at("amountBRaw"), amount_b_decimal))
+            return error("bad_amount");
+        quoteRequest["amountBRaw"] = amount_b_decimal;
+    }
+
+    const FfiResult quoteResult = call(amm_liquidity_quote, quoteRequest);
+    if (!quoteResult.ok)
+        return error(quoteResult.error.empty() ? "backend_error" : quoteResult.error);
+
+    // Success: wrap { amountARaw, amountBRaw, expectedLpRaw, lockedLpRaw,
+    // initialPriceRaw } in the standard envelope.
+    LogosMap out = quoteResult.value;
+    out["status"] = "ok";
+    out["error"] = "";
+    return out;
+}
+
+LogosMap AmmModuleImpl::createPool(const LogosMap& request) {
+    auto error = [](const std::string& err) {
+        return LogosMap{{"status", "error"}, {"error", err}};
+    };
+
+    // config_missing == no program id from AMM_PROGRAM_BIN (same as swapExactInQuote).
+    const std::string amm_program_id = ammProgramId();
+    if (amm_program_id.empty())
+        return error("config_missing");
+
+    // amm_create_pool_plan needs the config account for the twap program id the
+    // current-tick PDA derives from; a bad/absent config surfaces from the plan as
+    // config_unavailable (no bespoke check here — same as the swap plans).
+    const FfiResult configResult =
+        call(amm_config_id, json{{"ammProgramId", amm_program_id}});
+    if (!configResult.ok)
+        return error("backend_error");
+    const json config = readPublicAccount(jStr(configResult.value, "configId"));
+
+    // Normalize the pair + user holdings (incl. the caller-provided LP holding) to hex
+    // (base58 tolerated — transitional). A new pool has no pre-existing LP holding, so
+    // lpHoldingId is a fresh account the caller supplies; an empty/invalid id fails here.
+    const std::string token_a = normalizeAccountId(jStr(request, "tokenAId"));
+    const std::string token_b = normalizeAccountId(jStr(request, "tokenBId"));
+    const std::string holding_a = normalizeAccountId(jStr(request, "holdingAId"));
+    const std::string holding_b = normalizeAccountId(jStr(request, "holdingBId"));
+    const std::string user_lp = normalizeAccountId(jStr(request, "lpHoldingId"));
+    if (token_a.empty() || token_b.empty() || holding_a.empty() || holding_b.empty()
+        || user_lp.empty())
+        return error("invalid_account_id");
+
+    std::string amount_a_decimal;
+    std::string amount_b_decimal;
+    std::string deadline_decimal;
+    if (!jsonAmountToDecimal(request.value("amountARaw", json()), amount_a_decimal)
+        || !jsonAmountToDecimal(request.value("amountBRaw", json()), amount_b_decimal)
+        || !jsonAmountToDecimal(request.value("deadlineMs", json()), deadline_decimal))
+        return error("bad_amount");
+
+    // feeBps deserializes into a u32 in the plan request, so a missing / null / float / string
+    // value would fail the FFI's serde parse and leak an "invalid request JSON" error instead of
+    // a stable code. Require a JSON integer here; fee-tier support is validated in the plan op.
+    const json fee_val = request.value("feeBps", json());
+    if (!fee_val.is_number_integer())
+        return error("bad_fee_bps_amount");
+
+    // amm_create_pool_plan resolves the pool accounts (canonicalizing the pair),
+    // encodes NewDefinition (with the fee), and returns a ready-to-submit plan.
+    const FfiResult planResult = call(amm_create_pool_plan, json{
+        {"ammProgramId", amm_program_id},
+        {"config", config},
+        {"tokenAId", token_a},
+        {"tokenBId", token_b},
+        {"amountARaw", amount_a_decimal},
+        {"amountBRaw", amount_b_decimal},
+        {"feeBps", fee_val},
+        {"deadlineMs", deadline_decimal},
+        {"userHoldingAId", holding_a},
+        {"userHoldingBId", holding_b},
+        {"userHoldingLpId", user_lp},
+    });
+    if (!planResult.ok)
+        return error(planResult.error.empty() ? "backend_error" : planResult.error);
+    const json plan = planResult.value;
+
+    const std::vector<std::string> accounts = jsonStrVec(plan.value("accountIds", json::array()));
+    const std::vector<bool> signers = jsonBoolVec(plan.value("signingRequirements", json::array()));
+    const std::vector<uint8_t> instruction = jsonWordsToLeBytes(plan.value("instruction", json::array()));
+    const std::string program_id = jStr(plan, "programId");
+
+    AMM_TRACE("createPool: SUBMIT programId=" << program_id
+              << " instrBytes=" << instruction.size() << " accounts=" << accounts.size());
+
+    const std::string reply = modules().logos_execution_zone.send_generic_public_transaction(
+        accounts, signers, instruction, program_id);
+    AMM_TRACE("createPool: tx reply=" << reply);
+
+    const auto obj = json::parse(reply, nullptr, /*allow_exceptions=*/false);
+    if (!obj.is_object() || !obj.value("success", false))
+        return error("wallet_submission_failed");
+
+    // The native tx hash (64-char hex) is returned as-is — hex everywhere.
+    return LogosMap{{"status", "ok"}, {"error", ""}, {"transactionId", jStr(obj, "tx_hash")}};
+}
+
 LogosList AmmModuleImpl::tokenList() {
     LogosList out = LogosList::array();
 

--- a/modules/amm/src/amm_module_impl.cpp
+++ b/modules/amm/src/amm_module_impl.cpp
@@ -876,6 +876,146 @@ LogosMap AmmModuleImpl::createPool(const LogosMap& request) {
     return LogosMap{{"status", "ok"}, {"error", ""}, {"transactionId", jStr(obj, "tx_hash")}};
 }
 
+LogosMap AmmModuleImpl::addLiquidityQuote(const LogosMap& request) {
+    auto error = [](const std::string& err) {
+        return LogosMap{{"status", "error"}, {"error", err}};
+    };
+
+    // Normalize the pair to hex (the liquidity UI still sources base58 ids; transitional).
+    const std::string token_a = normalizeAccountId(jStr(request, "tokenAId"));
+    const std::string token_b = normalizeAccountId(jStr(request, "tokenBId"));
+    if (token_a.empty() || token_b.empty())
+        return error("invalid_token_id");
+
+    const std::string amm_program_id = ammProgramId();
+    if (amm_program_id.empty())
+        return error("config_missing");
+
+    std::string max_a_decimal;
+    std::string max_b_decimal;
+    if (!jsonAmountToDecimal(request.value("maxAmountARaw", json()), max_a_decimal)
+        || !jsonAmountToDecimal(request.value("maxAmountBRaw", json()), max_b_decimal))
+        return error("bad_amount");
+
+    // Derive the pool id (config-free) and read the pool account; its raw data is handed
+    // to the pricing op. An absent account has no data → `no_pool`.
+    const FfiResult poolId = call(amm_pool_id, json{
+        {"ammProgramId", amm_program_id},
+        {"tokenInId", token_a},
+        {"tokenOutId", token_b},
+    });
+    if (!poolId.ok)
+        return error(poolId.error.empty() ? "backend_error" : poolId.error);
+    const json pool = readPublicAccount(jStr(poolId.value, "poolId"));
+    const std::string pool_data = jStr(pool.value("account", json::object()), "data");
+
+    const FfiResult quoteResult = call(amm_add_liquidity_quote, json{
+        {"tokenAId", token_a},
+        {"tokenBId", token_b},
+        {"maxAmountARaw", max_a_decimal},
+        {"maxAmountBRaw", max_b_decimal},
+        {"poolData", pool_data},
+    });
+    if (!quoteResult.ok)
+        return error(quoteResult.error.empty() ? "backend_error" : quoteResult.error);
+
+    // Success: wrap { amountARaw, amountBRaw, expectedLpRaw, priceRaw } in the envelope.
+    LogosMap out = quoteResult.value;
+    out["status"] = "ok";
+    out["error"] = "";
+    return out;
+}
+
+LogosMap AmmModuleImpl::addLiquidity(const LogosMap& request) {
+    auto error = [](const std::string& err) {
+        return LogosMap{{"status", "error"}, {"error", err}};
+    };
+
+    // config_missing == no program id from AMM_PROGRAM_BIN (same as createPool).
+    const std::string amm_program_id = ammProgramId();
+    if (amm_program_id.empty())
+        return error("config_missing");
+
+    // amm_add_liquidity_plan needs the config account for the twap program id the
+    // current-tick PDA derives from; a bad/absent config surfaces from the plan.
+    const FfiResult configResult =
+        call(amm_config_id, json{{"ammProgramId", amm_program_id}});
+    if (!configResult.ok)
+        return error("backend_error");
+    const json config = readPublicAccount(jStr(configResult.value, "configId"));
+
+    // Normalize the pair + user holdings (incl. the LP holding that receives the minted LP)
+    // to hex (base58 tolerated — transitional).
+    const std::string token_a = normalizeAccountId(jStr(request, "tokenAId"));
+    const std::string token_b = normalizeAccountId(jStr(request, "tokenBId"));
+    const std::string holding_a = normalizeAccountId(jStr(request, "holdingAId"));
+    const std::string holding_b = normalizeAccountId(jStr(request, "holdingBId"));
+    const std::string user_lp = normalizeAccountId(jStr(request, "lpHoldingId"));
+    if (token_a.empty() || token_b.empty() || holding_a.empty() || holding_b.empty()
+        || user_lp.empty())
+        return error("invalid_account_id");
+
+    std::string max_a_decimal;
+    std::string max_b_decimal;
+    std::string min_lp_decimal;
+    std::string deadline_decimal;
+    if (!jsonAmountToDecimal(request.value("maxAmountARaw", json()), max_a_decimal)
+        || !jsonAmountToDecimal(request.value("maxAmountBRaw", json()), max_b_decimal)
+        || !jsonAmountToDecimal(request.value("minLpRaw", json()), min_lp_decimal)
+        || !jsonAmountToDecimal(request.value("deadlineMs", json()), deadline_decimal))
+        return error("bad_amount");
+
+    // Read the pool so the plan can use its stored vault / LP-definition ids (the guest
+    // asserts the provided vaults/LP against them — see amm_add_liquidity_plan).
+    const FfiResult poolId = call(amm_pool_id, json{
+        {"ammProgramId", amm_program_id},
+        {"tokenInId", token_a},
+        {"tokenOutId", token_b},
+    });
+    if (!poolId.ok)
+        return error(poolId.error.empty() ? "backend_error" : poolId.error);
+    const json pool = readPublicAccount(jStr(poolId.value, "poolId"));
+    const std::string pool_data = jStr(pool.value("account", json::object()), "data");
+
+    // amm_add_liquidity_plan resolves the pool accounts (canonicalizing the pair), encodes
+    // AddLiquidity (with the slippage floor), and returns a ready-to-submit plan.
+    const FfiResult planResult = call(amm_add_liquidity_plan, json{
+        {"ammProgramId", amm_program_id},
+        {"config", config},
+        {"tokenAId", token_a},
+        {"tokenBId", token_b},
+        {"maxAmountARaw", max_a_decimal},
+        {"maxAmountBRaw", max_b_decimal},
+        {"minLpRaw", min_lp_decimal},
+        {"deadlineMs", deadline_decimal},
+        {"userHoldingAId", holding_a},
+        {"userHoldingBId", holding_b},
+        {"userHoldingLpId", user_lp},
+        {"poolData", pool_data},
+    });
+    if (!planResult.ok)
+        return error(planResult.error.empty() ? "backend_error" : planResult.error);
+    const json plan = planResult.value;
+
+    const std::vector<std::string> accounts = jsonStrVec(plan.value("accountIds", json::array()));
+    const std::vector<bool> signers = jsonBoolVec(plan.value("signingRequirements", json::array()));
+    const std::vector<uint8_t> instruction = jsonWordsToLeBytes(plan.value("instruction", json::array()));
+    const std::string program_id = jStr(plan, "programId");
+
+    AMM_TRACE("addLiquidity: SUBMIT programId=" << program_id
+              << " instrBytes=" << instruction.size() << " accounts=" << accounts.size());
+
+    const std::string reply = modules().logos_execution_zone.send_generic_public_transaction(
+        accounts, signers, instruction, program_id);
+    AMM_TRACE("addLiquidity: tx reply=" << reply);
+
+    const auto obj = json::parse(reply, nullptr, /*allow_exceptions=*/false);
+    if (!obj.is_object() || !obj.value("success", false))
+        return error("wallet_submission_failed");
+
+    return LogosMap{{"status", "ok"}, {"error", ""}, {"transactionId", jStr(obj, "tx_hash")}};
+}
+
 LogosList AmmModuleImpl::tokenList() {
     LogosList out = LogosList::array();
 

--- a/modules/amm/src/amm_module_impl.h
+++ b/modules/amm/src/amm_module_impl.h
@@ -101,6 +101,39 @@ public:
                                 const nlohmann::json& max_in,
                                 const nlohmann::json& deadline);
 
+    /// Prices creating a pool for (tokenAId, tokenBId) from the two deposit amounts.
+    /// A pure preview — no chain reads, and no fee needed (the fee is not part of the
+    /// pool PDA and doesn't affect the opening LP/price). Returns `{ status:"ok",
+    /// error:"", amountARaw, amountBRaw, expectedLpRaw, lockedLpRaw, initialPriceRaw }`
+    /// computed via the shared `amm_core` opening-LP math, so `expectedLpRaw` is
+    /// exactly what the guest mints. `request` carries `{ tokenAId, tokenBId,
+    /// amountARaw, amountBRaw }` (ids hex or base58, normalized to hex; amounts a JSON
+    /// integer or decimal string). On failure: `{ status:"error", error:<code> }` —
+    /// `invalid_token_id`, `same_token_pair`, `bad_amount` (an amount field is present
+    /// but not a valid integer — e.g. a float, from `jsonAmountToDecimal`),
+    /// `amount_required` (an amount field is omitted), `invalid_raw_amount` (non-digit or
+    /// beyond the u128 range), `amount_must_be_positive` (zero), `amount_too_low`
+    /// (deposits below the locked minimum), or `backend_error`. `amount_required`,
+    /// `invalid_raw_amount`, `amount_must_be_positive`, `same_token_pair`, and
+    /// `amount_too_low` come from the FFI; the rest from the module. The caller decides
+    /// create-vs-add by pool existence before calling this.
+    LogosMap liquidityQuote(const LogosMap& request);
+
+    /// Submits a `NewDefinition` transaction creating the pool for the request's pair.
+    /// `request` carries `{ tokenAId, tokenBId, holdingAId, holdingBId, lpHoldingId,
+    /// amountARaw, amountBRaw, feeBps, deadlineMs }` (ids hex or base58, normalized to
+    /// hex; amounts/deadline a JSON integer or decimal string, deadline a u64 unix-ms).
+    /// The caller provides `lpHoldingId` — a fresh (empty) account the guest initializes
+    /// and mints the creator's LP tokens into; a new pool has no pre-existing LP holding,
+    /// and the module never creates wallet accounts. On success:
+    /// `{ status:"ok", error:"", transactionId:<hex tx hash> }`. On failure:
+    /// `{ status:"error", error:<code> }` — `config_missing`, `backend_error`,
+    /// `invalid_account_id`, `bad_amount` (malformed amount/deadline), `bad_fee_bps_amount`
+    /// (`feeBps` not a JSON integer), `wallet_submission_failed`, or a plan code (e.g.
+    /// `invalid_fee_tier`, `config_unavailable`). Unlike the swaps, a submit failure carries
+    /// a code so the create-pool UI can tell the user why.
+    LogosMap createPool(const LogosMap& request);
+
     /// Reads the token list config at TOKENS_CONFIG (a JSON array of
     /// { symbol, name, definitionId, holding, decimals }) and returns it,
     /// normalizing definitionId/holding to lowercase hex. Empty list if

--- a/modules/amm/src/amm_module_impl.h
+++ b/modules/amm/src/amm_module_impl.h
@@ -134,6 +134,16 @@ public:
     /// a code so the create-pool UI can tell the user why.
     LogosMap createPool(const LogosMap& request);
 
+    /// Lists the connected wallet's fungible token holdings for the account
+    /// selector: `[{ accountId (hex), accountType:"TokenHolding", definitionId
+    /// (base58), definitionIdHex (hex), balanceRaw }]` — one row per holding
+    /// account, every token, including zero-balance holdings. Narrowing to a
+    /// specific token is the selector's job. `wallet_open` gates the wallet read;
+    /// an empty list on a closed wallet, unset AMM_PROGRAM_BIN, or a decode failure.
+    /// (Thin stopgap — token-holding listing is wallet/token data; see
+    /// token_holdings.rs.)
+    LogosList tokenHoldings(bool wallet_open);
+
     /// Reads the token list config at TOKENS_CONFIG (a JSON array of
     /// { symbol, name, definitionId, holding, decimals }) and returns it,
     /// normalizing definitionId/holding to lowercase hex. Empty list if

--- a/modules/amm/src/amm_module_impl.h
+++ b/modules/amm/src/amm_module_impl.h
@@ -134,6 +134,31 @@ public:
     /// a code so the create-pool UI can tell the user why.
     LogosMap createPool(const LogosMap& request);
 
+    /// Prices an `AddLiquidity` into the existing pool for (tokenAId, tokenBId) from the
+    /// two max deposit amounts. Reads the pool server-side (like the swap quotes) and runs
+    /// the guest's proportional-deposit math. Returns the same shape as `liquidityQuote`
+    /// minus the create-only locked LP: `{ status:"ok", error:"", amountARaw, amountBRaw,
+    /// expectedLpRaw, priceRaw }` — the actual ratio-matched deposits (display order), the
+    /// LP minted, and the pool's spot price. Slippage is applied at submit, not here.
+    /// `request` carries `{ tokenAId, tokenBId, maxAmountARaw, maxAmountBRaw }` (ids hex or
+    /// base58, normalized to hex; amounts a JSON integer or decimal string). On failure:
+    /// `{ status:"error", error:<code> }` — `invalid_token_id`, `config_missing`,
+    /// `bad_amount`, `no_pool`, `pair_mismatch`, `amount_too_low`, or `backend_error`.
+    LogosMap addLiquidityQuote(const LogosMap& request);
+
+    /// Submits an `AddLiquidity` transaction into the request's pool. `request` carries
+    /// `{ tokenAId, tokenBId, holdingAId, holdingBId, lpHoldingId, maxAmountARaw,
+    /// maxAmountBRaw, minLpRaw, deadlineMs }` (ids hex or base58, normalized to hex;
+    /// amounts/deadline a JSON integer or decimal string). `minLpRaw` is the caller's
+    /// slippage floor on the LP minted (the UI derives it from the quote's expectedLpRaw
+    /// and its slippage control). `lpHoldingId` is the holding that receives the minted LP.
+    /// On success: `{ status:"ok", error:"", transactionId:<hex tx hash> }`. On failure:
+    /// `{ status:"error", error:<code> }` — `config_missing`, `backend_error`,
+    /// `invalid_account_id`, `bad_amount`, `same_token_pair` (from `amm_pool_id` or the plan),
+    /// `wallet_submission_failed`, or a plan code (e.g. `no_pool`, `pair_mismatch`,
+    /// `config_unavailable`).
+    LogosMap addLiquidity(const LogosMap& request);
+
     /// Lists the connected wallet's fungible token holdings for the account
     /// selector: `[{ accountId (hex), accountType:"TokenHolding", definitionId
     /// (base58), definitionIdHex (hex), balanceRaw }]` — one row per holding


### PR DESCRIPTION
Introduce the add-liquidity vertical mirroring the swap + createPool patterns, for depositing into an existing pool via the AddLiquidity instruction.

FFI (amm_ffi):
- add_liquidity_quote — decode poolData, orient the caller's max amounts to the pool's canonical order, run the guest's exact ideal->actual->delta_lp math, and return { amountARaw, amountBRaw, expectedLpRaw, priceRaw } in display order. Slippage-free like create's quote; the min-LP floor is applied at submit.
- add_liquidity_plan — canonicalize (token, max-amount, holding) as one unit, take vaults + LP definition from poolData, emit the 10-account AddLiquidity order (only the user holdings a/b/LP sign). Takes minLpRaw directly, like swap_exact_in_plan takes min_out.

Shared with createPool: extract canonical_triples (the pair/amount/holding canonical swap) and plan_response (the tx-submission envelope); both the create and add plans now use them.