### PR TITLE
fix(amm): restore liquidity controls after refresh

### DIFF
--- a/apps/amm/src/AmmUiBackend.cpp
+++ b/apps/amm/src/AmmUiBackend.cpp
@@ -113,7 +113,7 @@ QString AmmUiBackend::getBalance(QString accountIdHex, bool isPublic)
     return m_walletController->balance(accountIdHex, isPublic);
 }
 
-void AmmUiBackend::refreshNewPositionContext(QVariantMap request)
+QVariantMap AmmUiBackend::refreshNewPositionContext(QVariantMap request)
 {
     const bool refreshWalletAccounts =
         request.take(QStringLiteral("refreshWalletAccounts")).toBool();
@@ -125,11 +125,14 @@ void AmmUiBackend::refreshNewPositionContext(QVariantMap request)
         request = m_newPositionHints;
     }
     if (!walletStateReady()) {
-        setNewPositionContext(loadingContext());
-        return;
+        const QVariantMap context = loadingContext();
+        setNewPositionContext(context);
+        return context;
     }
-    setNewPositionContext(m_logos->amm_module.newPositionContext(
-        request, isWalletOpen(), refreshWalletAccounts));
+    const QVariantMap context = m_logos->amm_module.newPositionContext(
+        request, isWalletOpen(), refreshWalletAccounts);
+    setNewPositionContext(context);
+    return context;
 }
 
 void AmmUiBackend::syncWalletState()

--- a/apps/amm/src/AmmUiBackend.h
+++ b/apps/amm/src/AmmUiBackend.h
@@ -46,7 +46,7 @@ public slots:
     void refreshAccounts() override;
     void refreshBalances() override;
     QString getBalance(QString accountIdHex, bool isPublic) override;
-    void refreshNewPositionContext(QVariantMap request) override;
+    QVariantMap refreshNewPositionContext(QVariantMap request) override;
     // Return the new wallet's BIP39 mnemonic (empty string on failure) so the
     // UI can force a one-time seed-phrase backup step.
     QString createNewDefault(QString password) override;

--- a/apps/amm/src/AmmUiBackend.rep
+++ b/apps/amm/src/AmmUiBackend.rep
@@ -30,7 +30,8 @@ class AmmUiBackend
     // The QVariant payloads are stable maps/lists so the UI never assembles AMM
     // transactions or duplicates quote state.
     PROP(QVariantMap newPositionContext READONLY)
-    SLOT(void refreshNewPositionContext(QVariantMap request))
+    // Return the published context so the QML refresh watcher always settles.
+    SLOT(QVariantMap refreshNewPositionContext(QVariantMap request))
 
     // Wallet lifecycle. createNewDefault() is the happy path: it creates a
     // fresh wallet at the canonical walletHome with no path picking. createNew()

--- a/apps/amm/tests/qml/tst_LiquidityPage.qml
+++ b/apps/amm/tests/qml/tst_LiquidityPage.qml
@@ -15,11 +15,17 @@ TestCase {
 
         QtObject {
             property bool walletStateReady: false
+            property int contextRefreshCalls: 0
             property var newPositionContext: ({
                 "status": "ready",
                 "tokens": [],
                 "feeTiers": []
             })
+
+            function refreshNewPositionContext(request) {
+                ++contextRefreshCalls
+                return newPositionContext
+            }
         }
     }
 
@@ -47,6 +53,18 @@ TestCase {
         verify(compactSteps.implicitHeight > 0)
         verify(form.width > 0)
         verify(form.width <= page.width - 32)
+    }
+
+    Component {
+        id: runtimeComponent
+
+        QtObject {
+            function watch(value, succeeded, failed) {
+                if (value === undefined)
+                    return
+                succeeded(value)
+            }
+        }
     }
 
     Component {
@@ -85,6 +103,32 @@ TestCase {
 
         compare(page.flow.contextHints(false).refreshWalletAccounts, false)
         compare(page.flow.contextHints(true).refreshWalletAccounts, true)
+    }
+
+    function test_refreshPositionCompletesAndReenablesTokenSelection() {
+        var backend = createTemporaryObject(backendComponent, testCase, {
+            "walletStateReady": true
+        })
+        var runtime = createTemporaryObject(runtimeComponent, testCase)
+        var page = createTemporaryObject(pageComponent, testCase, {
+            "backend": backend,
+            "runtime": runtime
+        })
+        verify(backend)
+        verify(runtime)
+        verify(page)
+
+        var refreshButton = findChild(page, "refreshPositionButton")
+        var tokenAInput = findChild(page, "tokenAAmountInput")
+        verify(refreshButton)
+        verify(tokenAInput)
+
+        refreshButton.clicked()
+
+        tryCompare(backend, "contextRefreshCalls", 1)
+        tryCompare(page.flow, "contextLoading", false)
+        compare(refreshButton.enabled, true)
+        compare(tokenAInput.tokenSelectionEnabled, true)
     }
 
     function test_staleContextCompletionCannotFinishNewerRefresh() {


### PR DESCRIPTION
## Summary

- Return the refreshed position context through the Qt Remote Objects interface.
- Prevent the Liquidity refresh action from leaving the form controls disabled.
- Add regression coverage for refresh completion and token selection recovery.

## Root cause

`refreshNewPositionContext` was declared as `void` but called through `logos.watch`. The watcher never settled after a refresh, leaving `contextLoading` true and disabling the Liquidity form.

Closes #245 