### PR TITLE
fix(apps/amm): repair addCustomToken — restore token resolution and c…

### DIFF
--- a/apps/amm/src/AmmUiBackend.cpp
+++ b/apps/amm/src/AmmUiBackend.cpp
@@ -364,6 +364,11 @@ QVariantMap AmmUiBackend::addCustomToken(QString tokenId)
     // real fungible token (a non-fungible / unreadable id yields no row).
     QVariantMap probe;
     probe.insert(QStringLiteral("tokenIds"), QVariantList{id});
+    const QVariantList rows = m_logos->amm_module.resolveTokens(probe, isWalletOpen());
+    if (rows.isEmpty())
+        return QVariantMap{{QStringLiteral("ok"), false},
+                           {QStringLiteral("error"), QStringLiteral("unresolved")}};
+
     const QVariantMap token = rows.first().toMap();
     const QString canonicalId = token.value(QStringLiteral("definitionId")).toString();
     if (canonicalId.isEmpty())
@@ -378,6 +383,7 @@ QVariantMap AmmUiBackend::addCustomToken(QString tokenId)
                                {QStringLiteral("error"), QStringLiteral("backend_error")}};
     }
     return QVariantMap{{QStringLiteral("ok"), true}, {QStringLiteral("token"), token}};
+}
 
 QString AmmUiBackend::customTokenStorePath() const
 {


### PR DESCRIPTION
…losing brace

The Copilot Autofix squash reworked addCustomToken to persist the canonical definitionId (and to fail when the store write fails), but it deleted the line that resolves the token — `const QVariantList rows = resolveTokens(probe, …)` — while still calling `rows.first()`, and it dropped the function's closing brace. The result didn't compile: `rows` was undefined and customTokenStorePath parsed as a nested definition ("function definition is not allowed here").

Restore the resolveTokens call and the `rows.isEmpty()` guard before `rows` is used, and re-add the closing brace. The autofix's intent is preserved: resolve the pasted id, keep the canonical definitionId, persist it, and surface a backend_error if saveCustomTokenIds fails